### PR TITLE
Fix payment booking and pass validation flow

### DIFF
--- a/Client/src/app/paymentTesting/page.tsx
+++ b/Client/src/app/paymentTesting/page.tsx
@@ -4,16 +4,27 @@ import React, { useState } from "react";
 
 const startPayment = async (bookingId: string) => {
     try {
-        const response = await fetch(`${process.env.BACKEND_URL}/payment?eventId=${bookingId}`, {
+        const response = await fetch(`${process.env.BACKEND_URL}/api/book-ticket`, {
             method: "POST",
             headers: {
+                "Content-Type": "application/json",
                 Authorization: `Bearer ${localStorage.getItem(
                     "accessToken",
                 )}`,
             },
+            body: JSON.stringify({
+                eventId: bookingId,
+                passType: "General",
+                friends: [],
+            }),
         });
         if (response.ok) {
-            console.log("Payment started successfully");
+            const data = await response.json();
+            if (data.data?.paymentUrl) {
+                window.location.href = data.data.paymentUrl;
+                return;
+            }
+            console.log("Pass created successfully");
         } else {
             console.error("Failed to start payment");
         }

--- a/Server/package.json
+++ b/Server/package.json
@@ -8,7 +8,8 @@
         "setup": "npm install && npm update",
         "start": "node src/server.js",
         "seed": "node src/seed.js",
-        "dev": "nodemon src/server.js"
+        "dev": "nodemon src/server.js",
+        "test": "node --test"
     },
     "keywords": [
         "express",

--- a/Server/src/controllers/passes.controller.js
+++ b/Server/src/controllers/passes.controller.js
@@ -1,45 +1,139 @@
 const asyncHandler = require("express-async-handler");
-const express = require("express");
-const auth = require("../middleware/oauth.js");
 const Event = require("../models/events.model.js");
 const Pass = require("../models/passes.model.js");
 const User = require("../models/users.model.js");
 const mongoose = require("mongoose");
-const nodemailer = require("nodemailer");
 const crypto = require("crypto");
 const { v4: uuidv4 } = require("uuid");
 const axios = require("axios");
 const qs = require("qs");
-const { listeners } = require("../models/registration.model.js");
 
 const CONFIG = {
-  PRODUCTION: {
+  production: {
     AUTH_URL: "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
-    BASE_URL: "	https://api.phonepe.com/apis/pg",
+    BASE_URL: "https://api.phonepe.com/apis/pg",
     CHECKOUT_SCRIPT: "https://mercury.phonepe.com/web/bundle/checkout.js",
   },
-  STAGING: {
-    AUTH_URL: "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
-    BASE_URL: "	https://api.phonepe.com/apis/pg",
+  sandbox: {
+    AUTH_URL: "https://api-preprod.phonepe.com/apis/pg-sandbox/v1/oauth/token",
+    BASE_URL: "https://api-preprod.phonepe.com/apis/pg-sandbox",
+    CHECKOUT_SCRIPT: "https://mercury-uat.phonepe.com/web/bundle/checkout.js",
   },
-  CLIENT_VERSION: "1.0",
+  CLIENT_VERSION: "1",
 };
 
-// Environment configuration - use environment variables for security
-const ENVIRONMENT = process.env.PHONEPE_ENV;
-const CLIENT_ID = process.env.PHONEPE_CLIENT_ID;
-const CLIENT_SECRET = process.env.PHONEPE_CLIENT_SECRET;
+const getPhonePeConfig = () => {
+  const configuredEnv = String(process.env.PHONEPE_ENV || "").toLowerCase();
+
+  if (["production", "prod", "live"].includes(configuredEnv)) {
+    return CONFIG.production;
+  }
+
+  if (["sandbox", "staging", "test", "preprod", "uat", "development"].includes(configuredEnv)) {
+    return CONFIG.sandbox;
+  }
+
+  return String(process.env.PHONEPE_CLIENT_ID || "").startsWith("TEST-")
+    ? CONFIG.sandbox
+    : CONFIG.production;
+};
+
+const normalizePhonePeStatus = (paymentStatus = {}) => {
+  const data = paymentStatus.data || paymentStatus;
+  return {
+    state: paymentStatus.state || data.state,
+    orderId: paymentStatus.orderId || data.orderId,
+    amount: paymentStatus.amount || data.amount,
+    paymentDetails: paymentStatus.paymentDetails || data.paymentDetails || [],
+    reason: paymentStatus.reason || data.reason,
+  };
+};
+
+const sanitizeFriends = (friends = []) => {
+  if (!Array.isArray(friends)) {
+    return [];
+  }
+
+  return friends.slice(0, 9).map((friend) => ({
+    name: String(friend?.name || "Friend").trim().slice(0, 80) || "Friend",
+    email: friend?.email ? String(friend.email).trim().slice(0, 120) : undefined,
+    phone: friend?.phone ? String(friend.phone).trim().slice(0, 20) : undefined,
+  }));
+};
+
+const buildQRStrings = (user, friends = []) => {
+  const qrStrings = [
+    {
+      id: uuidv4(),
+      personType: "user",
+      personIndex: 0,
+      personName: user?.name || "Main User",
+      qrScanned: false,
+      scannedAt: null,
+    },
+  ];
+
+  friends.slice(0, 9).forEach((friend, index) => {
+    qrStrings.push({
+      id: uuidv4(),
+      personType: "friend",
+      personIndex: index + 1,
+      personName: friend.name || `Friend ${index + 1}`,
+      qrScanned: false,
+      scannedAt: null,
+    });
+  });
+
+  return qrStrings;
+};
+
+const reserveSeats = async (eventId, ticketCount) => {
+  return Event.findOneAndUpdate(
+    {
+      _id: eventId,
+      $expr: {
+        $lte: [
+          { $add: [{ $ifNull: ["$registrationCount", 0] }, ticketCount] },
+          "$totalSeats",
+        ],
+      },
+    },
+    { $inc: { registrationCount: ticketCount } },
+    { new: true },
+  );
+};
+
+const releaseReservedSeats = async (pass) => {
+  if (!pass?.seatsReserved) {
+    return;
+  }
+
+  const ticketCount = pass.ticketCount || 1 + (pass.friends?.length || 0);
+  await Event.findByIdAndUpdate(pass.eventId, {
+    $inc: { registrationCount: -ticketCount },
+  });
+  pass.seatsReserved = false;
+};
+
+const findQRString = (pass, qrId) => {
+  return pass?.qrStrings?.find(
+    (qr) => qr.id === qrId || qr._id?.toString() === qrId,
+  );
+};
 
 const getPhonePeAccessToken = async () => {
   try {
-    console.log("[PhonePe] Requesting access token...");
+    const config = getPhonePeConfig();
+    const clientVersion =
+      process.env.PHONEPE_CLIENT_VERSION || CONFIG.CLIENT_VERSION;
+
     const response = await axios.post(
-      "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
+      config.AUTH_URL,
       qs.stringify({
         client_id: process.env.PHONEPE_CLIENT_ID,
         client_secret: process.env.PHONEPE_CLIENT_SECRET,
         grant_type: "client_credentials",
-        client_version: "1",
+        client_version: clientVersion,
       }),
       {
         headers: {
@@ -48,7 +142,12 @@ const getPhonePeAccessToken = async () => {
       },
     );
 
-    return response.data.access_token;
+    const accessToken = response.data?.access_token || response.data?.data?.access_token;
+    if (!accessToken) {
+      throw new Error("PhonePe auth response did not include an access token");
+    }
+
+    return accessToken;
   } catch (error) {
     console.error(
       "[PhonePe] Auth Error:",
@@ -63,7 +162,11 @@ const getPhonePeAccessToken = async () => {
 // Create Payment Order
 const createPhonePeOrder = async (orderData) => {
   try {
-    console.log("Creating PhonePe order with data:", orderData);
+    const config = getPhonePeConfig();
+    console.log("Creating PhonePe order:", {
+      merchantOrderId: orderData.merchantOrderId,
+      amount: orderData.amount,
+    });
     const accessToken = await getPhonePeAccessToken();
 
     const payload = {
@@ -86,7 +189,7 @@ const createPhonePeOrder = async (orderData) => {
     };
 
     const response = await axios.post(
-      `${CONFIG.PRODUCTION.BASE_URL}/checkout/v2/pay`,
+      `${config.BASE_URL}/checkout/v2/pay`,
       payload,
       {
         headers: {
@@ -97,7 +200,13 @@ const createPhonePeOrder = async (orderData) => {
       },
     );
 
-    return response.data;
+    const paymentOrder = response.data;
+    const paymentUrl = paymentOrder?.data?.redirectUrl || paymentOrder?.redirectUrl;
+    if (!paymentUrl) {
+      throw new Error("PhonePe order response did not include a payment URL");
+    }
+
+    return paymentOrder;
   } catch (error) {
     console.error("PhonePe order creation error:", {
       status: error.response?.status,
@@ -111,15 +220,19 @@ const createPhonePeOrder = async (orderData) => {
 };
 
 const bookTicket = async (req, res) => {
+  let pass;
   try {
-    console.log("Booking ticket request:", req.body);
-
-    // Validation
-    console.log("User:", req.user);
     if (!req.user?._id || !req.body.eventId) {
       return res.status(400).json({
         success: false,
         error: "User ID and Event ID are required",
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(req.body.eventId)) {
+      return res.status(400).json({
+        success: false,
+        error: "Invalid Event ID",
       });
     }
 
@@ -152,13 +265,15 @@ const bookTicket = async (req, res) => {
       }
     }
 
-    const friends = req.body.friends || [];
+    const friends = sanitizeFriends(req.body.friends);
     const totalTicketsNeeded = 1 + friends.length;
-    const totalAmount = event.ticketPrice * totalTicketsNeeded;
-    const amountInPaisa = totalAmount * 100;
+    const ticketPrice = Number(event.ticketPrice || 0);
+    const totalAmount = ticketPrice * totalTicketsNeeded;
+    const amountInPaisa = Math.round(totalAmount * 100);
+    const isPaidBooking = Boolean(event.isPaid && amountInPaisa > 0);
 
-    // Validation checks
-    if (event.remainingSeats < totalTicketsNeeded) {
+    const reservedEvent = await reserveSeats(event._id, totalTicketsNeeded);
+    if (!reservedEvent) {
       return res.status(400).json({
         success: false,
         error: "Insufficient tickets available",
@@ -168,69 +283,92 @@ const bookTicket = async (req, res) => {
     // Generate unique merchant order ID with timestamp
     const merchantOrderId = `TKT_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-    console.log("Generated merchantOrderId:", merchantOrderId);
-
-    // Create temporary pass
-    const pass = new Pass({
+    pass = new Pass({
       userId: req.user?._id,
       eventId: req.body.eventId,
       passType: req.body.passType || "General",
-      status: "pending",
-      paymentStatus: "pending",
+      status: isPaidBooking ? "pending" : "active",
+      passStatus: isPaidBooking ? "inactive" : "active",
+      paymentStatus: isPaidBooking ? "pending" : "completed",
       merchantOrderId,
       amount: totalAmount,
+      ticketCount: totalTicketsNeeded,
+      seatsReserved: true,
       friends,
       createdAt: new Date(),
       expiresAt: new Date(Date.now() + 20 * 60 * 1000),
     });
-    console.log("Creating pass:", pass);
-    await pass.save();
-    console.log("Pass created with ID:", pass._id);
 
-    // Create PhonePe payment order
+    if (!isPaidBooking) {
+      pass.confirmedAt = new Date();
+      pass.paymentDetails = {
+        amount: 0,
+        completedAt: new Date(),
+        source: "free_registration",
+        merchantOrderId,
+      };
+      pass.qrStrings = buildQRStrings(user, friends);
+      await pass.save();
+
+      return res.status(200).json({
+        success: true,
+        message: "Free pass created successfully",
+        data: {
+          passId: pass._id,
+          passUUID: pass.passUUID,
+          merchantOrderId,
+          amount: totalAmount,
+          amountInPaisa,
+          totalTickets: totalTicketsNeeded,
+          paymentRequired: false,
+          paymentUrl: null,
+          event: {
+            id: event._id,
+            title: event.name,
+            date: event.startDate,
+            venue: event.location,
+          },
+          qrStrings: pass.qrStrings,
+          friends,
+        },
+      });
+    }
+
+    await pass.save();
+
     const orderData = {
       merchantOrderId,
       amount: amountInPaisa,
-      userId: req.body.userId,
+      userId: req.user._id.toString(),
       eventId: req.body.eventId,
-      eventName: event.title,
+      eventName: event.name,
       passType: req.body.passType || "General",
       friends,
-      mobileNumber: user.phone,
+      mobileNumber: user.phoneNumber,
     };
 
-    const paymentOrder = await createPhonePeOrder(orderData);
+    let paymentOrder;
+    try {
+      paymentOrder = await createPhonePeOrder(orderData);
+    } catch (error) {
+      pass.status = "payment_failed";
+      pass.passStatus = "inactive";
+      pass.paymentStatus = "failed";
+      pass.paymentDetails = {
+        amount: amountInPaisa,
+        failedAt: new Date(),
+        source: "order_creation",
+        reason: error.message,
+        merchantOrderId,
+      };
+      await releaseReservedSeats(pass);
+      await pass.save();
+      throw error;
+    }
 
-    // Update pass with payment details
     pass.phonePeOrderId = paymentOrder.data?.orderId || paymentOrder.orderId;
     pass.paymentUrl =
       paymentOrder.data?.redirectUrl || paymentOrder.redirectUrl;
-    console.log("saving pass");
-    await pass.save();
-
-    console.log(
-      "Redirect URL:",
-      `${process.env.BASE_URL}/api/payment/callback/${orderData.merchantOrderId}`,
-    );
-    console.log("Webhook URL:", `${process.env.BASE_URL}/api/payment/webhook`);
-    console.log("Payment order created successfully");
-
-    // Generate QR strings for the user and friends
-
-    const qrStrings = [];
-    qrStrings.push({
-      id: uuidv4(),
-      personName: user?.name || "You",
-    });
-    if (friends.length > 0) {
-      for (const friend of friends) {
-        qrStrings.push({
-          personName: friend.name || "Friend",
-        });
-      }
-    }
-    pass.qrStrings = qrStrings;
-    console.log("Saving QR strings to pass");
     await pass.save();
 
     return res.status(200).json({
@@ -247,15 +385,25 @@ const bookTicket = async (req, res) => {
         expiresAt: pass.expiresAt,
         event: {
           id: event._id,
-          title: event.title,
-          date: event.date,
-          venue: event.venue,
+          title: event.name,
+          date: event.startDate,
+          venue: event.location,
         },
-        qrStrings: qrStrings,
-        friends: friends,
+        qrStrings: [],
+        friends,
       },
     });
   } catch (error) {
+    if (pass?.seatsReserved && pass.paymentStatus !== "completed") {
+      try {
+        await releaseReservedSeats(pass);
+        if (!pass.isNew) {
+          await pass.save();
+        }
+      } catch (releaseError) {
+        console.error("Seat reservation release failed:", releaseError);
+      }
+    }
     console.error("Ticket booking error:", error);
     return res.status(500).json({
       success: false,
@@ -269,11 +417,10 @@ const bookTicket = async (req, res) => {
 // Enhanced Payment Status Check with Integrated Processing
 const checkPaymentStatus = async (merchantOrderId, shouldProcess = false) => {
   try {
+    const config = getPhonePeConfig();
     const accessToken = await getPhonePeAccessToken();
-    console.log("[STATUS] Access token acquired");
 
-    const url = `${CONFIG.PRODUCTION.BASE_URL}/checkout/v2/order/${merchantOrderId}/status`;
-    console.log("[STATUS] Checking status at:", url);
+    const url = `${config.BASE_URL}/checkout/v2/order/${merchantOrderId}/status`;
 
     const response = await axios.get(url, {
       headers: {
@@ -284,13 +431,11 @@ const checkPaymentStatus = async (merchantOrderId, shouldProcess = false) => {
       timeout: 10000,
     });
 
-    console.log("[STATUS] Response from PhonePe:", response.data);
-
     const paymentData = response.data;
 
     // If shouldProcess is true, automatically process the payment based on status
     if (shouldProcess && paymentData) {
-      const paymentState = paymentData.state || paymentData.data?.state;
+      const paymentState = normalizePhonePeStatus(paymentData).state;
 
       if (paymentState === "COMPLETED") {
         await processPaymentConfirmation(
@@ -327,39 +472,64 @@ const processPaymentConfirmation = async (
   source = "callback",
 ) => {
   try {
-    console.log(
-      `[${source}] Processing payment confirmation for:`,
-      merchantOrderId,
-    );
-
-    // Find pass by merchantOrderId instead of using metadata
     const pass = await Pass.findOne({ merchantOrderId });
 
     if (!pass) {
       throw new Error(`Pass not found for merchantOrderId: ${merchantOrderId}`);
     }
 
-    // Check if already processed
+    const user = await User.findById(pass.userId).select("name");
+
     if (pass.paymentStatus === "completed") {
-      console.log(`[${source}] Payment already processed for pass:`, pass._id);
+      let repaired = false;
+      if (!pass.passUUID) {
+        pass.passUUID = uuidv4();
+        repaired = true;
+      }
+      if (!pass.qrStrings?.length) {
+        pass.qrStrings = buildQRStrings(user, pass.friends);
+        repaired = true;
+      }
+      if (pass.status !== "active" || pass.passStatus !== "active") {
+        pass.status = "active";
+        pass.passStatus = "active";
+        repaired = true;
+      }
+      if (repaired) {
+        await pass.save();
+      }
+
       return {
         passId: pass._id,
-        passUUID: pass.passUUID || pass._id,
+        passUUID: pass.passUUID,
         success: true,
         message: "Payment already confirmed",
         alreadyProcessed: true,
       };
     }
 
-    // Update pass status
+    if (!pass.seatsReserved) {
+      const reservedEvent = await reserveSeats(
+        pass.eventId,
+        pass.ticketCount || 1 + (pass.friends?.length || 0),
+      );
+      if (!reservedEvent) {
+        throw new Error("Payment completed but no seats are available");
+      }
+      pass.seatsReserved = true;
+    }
+
+    const normalizedPayment = normalizePhonePeStatus(paymentStatus);
+
     pass.status = "active";
+    pass.passStatus = "active";
     pass.paymentStatus = "completed";
     pass.confirmedAt = new Date();
     pass.paymentDetails = {
-      orderId: paymentStatus.orderId,
-      transactionId: paymentStatus.paymentDetails?.[0]?.transactionId,
-      amount: paymentStatus.amount,
-      paymentMode: paymentStatus.paymentDetails?.[0]?.paymentMode,
+      orderId: normalizedPayment.orderId,
+      transactionId: normalizedPayment.paymentDetails?.[0]?.transactionId,
+      amount: normalizedPayment.amount,
+      paymentMode: normalizedPayment.paymentDetails?.[0]?.paymentMode,
       completedAt: new Date(),
       source: source,
       merchantOrderId: merchantOrderId,
@@ -369,6 +539,9 @@ const processPaymentConfirmation = async (
     if (!pass.passUUID) {
       pass.passUUID = uuidv4();
     }
+    if (!pass.qrStrings?.length) {
+      pass.qrStrings = buildQRStrings(user, pass.friends);
+    }
 
     await pass.save();
 
@@ -376,11 +549,6 @@ const processPaymentConfirmation = async (
     await User.findByIdAndUpdate(pass.userId, {
       $inc: { activePasses: 1 },
     });
-
-    console.log(
-      `[${source}] Payment confirmed successfully for pass:`,
-      pass._id,
-    );
 
     return {
       passId: pass._id,
@@ -401,25 +569,24 @@ const processPaymentFailure = async (
   source = "callback",
 ) => {
   try {
-    console.log(`[${source}] Processing payment failure for:`, merchantOrderId);
-
     const pass = await Pass.findOne({
       merchantOrderId: merchantOrderId,
-      status: "pending",
     });
 
-    if (pass) {
-      // Update pass status to failed
+    if (pass && pass.paymentStatus !== "completed") {
+      const normalizedPayment = normalizePhonePeStatus(paymentStatus);
       pass.status = "payment_failed";
+      pass.passStatus = "inactive";
       pass.paymentStatus = "failed";
       pass.paymentDetails = {
-        orderId: paymentStatus.orderId,
-        amount: paymentStatus.amount,
+        orderId: normalizedPayment.orderId,
+        amount: normalizedPayment.amount,
         failedAt: new Date(),
         source: source,
-        reason: paymentStatus.reason || "Payment failed",
+        reason: normalizedPayment.reason || "Payment failed",
         merchantOrderId: merchantOrderId,
       };
+      await releaseReservedSeats(pass);
 
       await pass.save();
     }
@@ -443,8 +610,14 @@ const validateWebhookSignature = (username, password, receivedSignature) => {
       .createHash("sha256")
       .update(credentials)
       .digest("hex");
+    if (!receivedSignature || receivedSignature.length !== expectedSignature.length) {
+      return false;
+    }
 
-    return expectedSignature === receivedSignature;
+    return crypto.timingSafeEqual(
+      Buffer.from(expectedSignature),
+      Buffer.from(receivedSignature),
+    );
   } catch (error) {
     console.error("Error validating webhook signature:", error);
     return false;
@@ -468,34 +641,22 @@ const htmlRedirect = (url) => `
 // Enhanced Payment Callback Handler
 const handlePaymentCallback = async (req, res) => {
   try {
-    console.log("Payment callback initiated");
     const { merchantOrderId } = req.params;
-    console.log("[CALLBACK] Received callback for:", merchantOrderId);
 
-    // Step 1: Fetch status from PhonePe with processing enabled
     const paymentStatus = await checkPaymentStatus(merchantOrderId, true);
-    console.log("[CALLBACK] PhonePe status processed:", paymentStatus);
 
-    // Validate response
     if (!paymentStatus || typeof paymentStatus !== "object") {
       throw new Error("Invalid payment status response from PhonePe");
     }
 
-    const paymentState = paymentStatus.state || paymentStatus.data?.state;
+    const paymentState = normalizePhonePeStatus(paymentStatus).state;
     if (!paymentState) {
-      console.log(
-        '[CALLBACK] Payment status missing "state" field:',
-        paymentStatus,
-      );
       throw new Error("Missing 'state' in PhonePe response");
     }
 
-    // Find pass to get details
     const pass = await Pass.findOne({ merchantOrderId: merchantOrderId });
 
-    // Step 2: Route based on payment state
     if (paymentState === "COMPLETED") {
-      console.log("[CALLBACK] Payment completed. Redirecting to success");
       return res.redirect(
         302,
         `${process.env.FRONTEND_URL}/ticket/success?passId=${pass?._id}&uuid=${pass?.passUUID}`,
@@ -503,15 +664,12 @@ const handlePaymentCallback = async (req, res) => {
     }
 
     if (paymentState === "FAILED") {
-      console.log("[CALLBACK] Payment failed. Redirecting to failure");
       return res.redirect(
         302,
         `${process.env.FRONTEND_URL}/ticket/failure?passId=${pass ? pass._id : ""}&orderId=${merchantOrderId}`,
       );
     }
 
-    // PENDING or unknown status
-    console.log("[CALLBACK] Payment pending. Redirecting to pending page.");
     return res.redirect(
       302,
       `${process.env.FRONTEND_URL}/ticket/pending?orderId=${merchantOrderId}`,
@@ -533,12 +691,10 @@ const handlePaymentCallback = async (req, res) => {
 const handleManualStatusCheck = async (req, res) => {
   try {
     const { merchantOrderId } = req.params;
-    console.log("[MANUAL_CHECK] Checking status for:", merchantOrderId);
 
-    // Check status with processing enabled
     const paymentStatus = await checkPaymentStatus(merchantOrderId, true);
 
-    const paymentState = paymentStatus.state || paymentStatus.data?.state;
+    const paymentState = normalizePhonePeStatus(paymentStatus).state;
 
     return res.status(200).json({
       success: true,
@@ -560,7 +716,9 @@ const handleManualStatusCheck = async (req, res) => {
 // Enhanced Webhook Handler
 const handlePaymentWebhook = async (req, res) => {
   try {
-    console.log("Webhook received:", req.body);
+    const webhookBody = Buffer.isBuffer(req.body)
+      ? JSON.parse(req.body.toString("utf8"))
+      : req.body;
 
     // Validate webhook signature if configured
     if (
@@ -585,7 +743,10 @@ const handlePaymentWebhook = async (req, res) => {
       }
     }
 
-    const { event, payload } = req.body;
+    const { event, payload } = webhookBody || {};
+    if (!event || !payload?.merchantOrderId) {
+      return res.status(400).json({ error: "Invalid webhook payload" });
+    }
 
     if (event === "checkout.order.completed") {
       await processPaymentConfirmation(
@@ -711,33 +872,24 @@ const getPassForQR = async (req, res) => {
 const getTicketStatus = async (req, res) => {
   try {
     const { passId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(passId)) {
+      return res.status(400).json({ error: "Invalid Pass ID" });
+    }
 
-    const pass = await Pass.findById(passId)
-      .populate("userId", "name email phone")
-      .populate("eventId", "title date venue location");
+    let pass = await Pass.findById(passId)
+      .populate("userId", "name email phoneNumber")
+      .populate("eventId", "name startDate location");
 
     if (!pass) {
       return res.status(404).json({ error: "Pass not found" });
     }
 
-    // If payment is still pending, check status from PhonePe
-    if (pass.status === "pending" && pass.merchantOrderId) {
+    if (pass.paymentStatus === "pending" && pass.merchantOrderId) {
       try {
-        const paymentStatus = await checkPaymentStatus(pass.merchantOrderId);
-
-        if (paymentStatus.state === "COMPLETED") {
-          pass.status = "active";
-          pass.paymentStatus = "completed";
-          pass.confirmedAt = new Date();
-          if (!pass.passUUID) {
-            pass.passUUID = uuidv4();
-          }
-          await pass.save();
-        } else if (paymentStatus.state === "FAILED") {
-          pass.status = "payment_failed";
-          pass.paymentStatus = "failed";
-          await pass.save();
-        }
+        await checkPaymentStatus(pass.merchantOrderId, true);
+        pass = await Pass.findById(passId)
+          .populate("userId", "name email phoneNumber")
+          .populate("eventId", "name startDate location");
       } catch (error) {
         console.error("Error checking payment status:", error);
       }
@@ -748,7 +900,7 @@ const getTicketStatus = async (req, res) => {
       data: {
         pass: pass,
         qrCode:
-          pass.status === "active"
+          pass.paymentStatus === "completed" && pass.passUUID
             ? generateQRCode(pass.passUUID || pass._id)
             : null,
       },
@@ -768,12 +920,15 @@ const generateQRCode = (passIdentifier) => {
 const cleanupExpiredPasses = async () => {
   try {
     const expiredPasses = await Pass.find({
-      status: "pending",
+      paymentStatus: "pending",
       expiresAt: { $lt: new Date() },
     });
 
     for (const pass of expiredPasses) {
       pass.status = "expired";
+      pass.passStatus = "expired";
+      pass.paymentStatus = "failed";
+      await releaseReservedSeats(pass);
       await pass.save();
     }
 
@@ -789,11 +944,14 @@ const getPassByUUID = async (req, res) => {
       return res.status(400).json({ error: "Pass UUID is required" });
     }
 
-    const pass = await Pass.findOne({ passUUID: passUUID })
+    const pass = await Pass.findOne({
+      passUUID: passUUID,
+      paymentStatus: "completed",
+    })
       .populate("userId", "name")
       .populate("eventId", "name startDate")
       .select(
-        "eventId userId paymentStatus createdAt amount friends passUUID passType",
+        "eventId userId paymentStatus status createdAt amount friends passUUID passType ticketCount",
       );
 
     if (!pass) {
@@ -808,8 +966,8 @@ const getPassByUUID = async (req, res) => {
       passEventDate: pass.eventId?.startDate || "Unknown Date",
       passPaymentStatus: pass.paymentStatus || "ERROR",
       passCreatedAt: pass.createdAt || "NO",
-      passStatus: pass.paymentStatus || "ERROR",
-      passEnteries: pass.friends.length + 1, // Including the main userP
+      passStatus: pass.status || pass.paymentStatus || "ERROR",
+      passEnteries: pass.ticketCount || pass.friends.length + 1,
       eventId: pass.eventId?._id || "Unknown Event ID",
       // Additional fields that might be useful
     };
@@ -826,6 +984,10 @@ const getPassByUUID = async (req, res) => {
 
 const getPassByUserAndEvent = async (req, res) => {
   try {
+    if (!mongoose.Types.ObjectId.isValid(req.body.eventId)) {
+      return res.status(400).json({ error: "Invalid Event ID" });
+    }
+
     const passes = await Pass.find({
       userId: req.user._id,
       eventId: req.body.eventId,
@@ -849,8 +1011,6 @@ const getPassByUserAndEvent = async (req, res) => {
       };
     });
 
-    console.log("Passes found:", passesData.length);
-
     return res.status(200).json({
       passes: passesData,
       count: passesData.length,
@@ -863,40 +1023,34 @@ const getPassByUserAndEvent = async (req, res) => {
 };
 const getPassByQrStringsAndPassUUID = async (req, res) => {
   try {
+    if (!req.body.passUUID || !req.body.qrId) {
+      return res.status(400).json({ error: "Pass UUID and QR ID are required" });
+    }
+
     const pass = await Pass.findOne({
       passUUID: req.body.passUUID,
-    }).populate("eventId");
-
-    console.log(req.body.qrId);
-    console.log(pass);
+      paymentStatus: "completed",
+    })
+      .populate("eventId", "name")
+      .populate("userId", "name");
 
     if (!pass) {
       return res.status(404).json({ error: "Valid pass not found" });
     }
 
-    let person = null;
-
-    // Check if qrStrings exists and is an array
-    if (pass.qrStrings && Array.isArray(pass.qrStrings)) {
-      // Use for...of loop to iterate over the actual objects
-      for (const qr of pass.qrStrings) {
-        if (qr._id && qr._id.toString() === req.body.qrId) {
-          console.log("QR found", qr);
-          person = qr;
-          break;
-        }
-      }
+    const person = findQRString(pass, req.body.qrId);
+    if (!person) {
+      return res.status(404).json({ error: "QR code not found" });
     }
-
-    console.log("Found person:", person);
 
     return res.status(200).json({
       success: true,
       data: {
-        buyer: pass.userId.name,
-        event: pass.eventId.name,
+        buyer: pass.userId?.name || "Unknown buyer",
+        event: pass.eventId?.name || "Unknown event",
         person,
         amount: pass.amount,
+        paymentStatus: pass.paymentStatus,
       },
     });
   } catch (error) {
@@ -906,35 +1060,48 @@ const getPassByQrStringsAndPassUUID = async (req, res) => {
 };
 const Accept = async (req, res) => {
   try {
-    let passUUID = req.body.uuid;
+    const passUUID = req.body.uuid;
     if (!passUUID) {
       return res.status(400).json({ error: "Pass UUID is required" });
     }
-    let qrId = req.body.qrId;
+    const qrId = req.body.qrId;
     if (!qrId) {
       return res.status(400).json({ error: "QR ID is required" });
     }
 
-    // Find pass by passUUID field, not by _id
     const pass = await Pass.findOne({ passUUID });
     if (!pass) {
       return res.status(404).json({ error: "Pass not found" });
     }
 
-    // Find the QR string by _id
-    const qrString = pass.qrStrings.find((qr) => qr._id.toString() === qrId);
+    if (pass.paymentStatus !== "completed") {
+      return res.status(400).json({ error: "Pass is not active" });
+    }
+    if (pass.status !== "active" || pass.passStatus !== "active") {
+      pass.status = "active";
+      pass.passStatus = "active";
+    }
+
+    const qrString = findQRString(pass, qrId);
     if (!qrString) {
       return res.status(404).json({ error: "QR code not found" });
     }
 
-    if (qrString.isScanned) {
+    if (qrString.qrScanned) {
       return res.status(400).json({ error: "QR code already scanned" });
     }
 
     qrString.scannedAt = new Date();
     qrString.qrScanned = true;
+    if (pass.qrStrings.every((qr) => qr.qrScanned || qr._id.toString() === qrString._id.toString())) {
+      pass.isScanned = true;
+      pass.timeScanned = qrString.scannedAt;
+    }
     await pass.save();
-    return res.status(200).json({ message: "Pass scanned successfully" });
+    return res.status(200).json({
+      message: "Pass scanned successfully",
+      scannedAt: qrString.scannedAt,
+    });
   } catch (error) {
     console.error("Accept pass error:", error);
     return res.status(500).json({ error: "Internal server error" });
@@ -975,11 +1142,6 @@ const Accept = async (req, res) => {
 
 const canScan = async (req, res) => {
   let user = req.user;
-  let eventId = req.body.eventId;
-  const event = await Event.findById(eventId);
-  if (user.role !== "admin" && user.role !== "event_manager") {
-    return res.status(403).json({ error: "Forbidden: Invalid role" });
-  }
   try {
     if (user.role !== "admin") {
       return res.status(403).json({ error: "Forbidden: Invalid role" });
@@ -994,22 +1156,22 @@ const canScan = async (req, res) => {
 
 const admnDetails = async (req, res) => {
   let user = req.user;
-  let eventId = req.body.eventId;
-  const event = await Event.findById(eventId);
-  if (user.role !== "admin" && user.role !== "event_manager") {
-    return res.status(403).json({ error: "Forbidden: Invalid role" });
-  }
   try {
     if (user.role !== "admin") {
       return res.status(403).json({ error: "Forbidden: Invalid role" });
     }
-    // fetch all passes with completed
-    const passes = await Pass.find({ paymentStatus: "completed" });
-    // calculate total number of passes
-    const totalDocuments = passes.length - 3;
-    // add all the amount - 9* length of documents
+    const query = { paymentStatus: "completed" };
+    if (req.query.eventId && mongoose.Types.ObjectId.isValid(req.query.eventId)) {
+      query.eventId = req.query.eventId;
+    }
+
+    const passes = await Pass.find(query);
+    const totalOrders = passes.length;
+    const totalTickets = passes.reduce(
+      (acc, pass) => acc + (pass.ticketCount || 1 + (pass.friends?.length || 0)),
+      0,
+    );
     const totalAmount = passes.reduce((acc, pass) => acc + pass.amount, 0);
-    const totalAmountAfterAdjustment = totalAmount - 5 - 9 * totalDocuments;
 
     const y2kPasses = await Pass.find({
       paymentStatus: "completed",
@@ -1019,8 +1181,9 @@ const admnDetails = async (req, res) => {
 
     return res.status(200).json({
       message: "Details fetched successfully",
-      passes: totalDocuments,
-      amount: totalAmountAfterAdjustment,
+      orders: totalOrders,
+      passes: totalTickets,
+      amount: totalAmount,
       y2kPasses: y2kPassesCount,
     });
   } catch (error) {
@@ -1041,4 +1204,11 @@ module.exports = {
   cleanupExpiredPasses,
   getPassByUUID,
   admnDetails,
+  _test: {
+    buildQRStrings,
+    getPhonePeConfig,
+    normalizePhonePeStatus,
+    sanitizeFriends,
+    validateWebhookSignature,
+  },
 };

--- a/Server/src/models/passes.model.js
+++ b/Server/src/models/passes.model.js
@@ -1,4 +1,3 @@
-const { bool, boolean } = require("joi");
 const mongoose = require("mongoose");
 const { v4: uuidv4 } = require('uuid');
 
@@ -16,7 +15,12 @@ const passSchema = new mongoose.Schema({
 	passStatus: {	
 		type: String,
 		enum: ["active", "inactive", "expired", "revoked"],
-		default: "active",
+		default: "inactive",
+	},
+	status: {
+		type: String,
+		enum: ["pending", "active", "payment_failed", "expired", "revoked"],
+		default: "pending",
 	},
 	paymentStatus: {
 		type: String,
@@ -39,6 +43,19 @@ const passSchema = new mongoose.Schema({
 		type: Number,
 		required: true,
 		min: 0,
+	},
+	ticketCount: {
+		type: Number,
+		required: true,
+		default: 1,
+		min: 1,
+	},
+	seatsReserved: {
+		type: Boolean,
+		default: false,
+	},
+	expiresAt: {
+		type: Date,
 	},
 	paymentDetails: {
 		orderId: String,
@@ -73,6 +90,9 @@ const passSchema = new mongoose.Schema({
 			type: String,
 			enum: ["user", "friend"],
 			
+		},
+		personIndex: {
+			type: Number,
 		},
 		personName: {
 			type: String,
@@ -124,16 +144,19 @@ const passSchema = new mongoose.Schema({
 });
 
 passSchema.pre('save', function(next) {
-	if (!this.passUUID && this.passStatus === 'active') {
+	const isConfirmed = this.paymentStatus === 'completed' || this.status === 'active' || this.passStatus === 'active';
+
+	if (!this.passUUID && isConfirmed) {
 		this.passUUID = uuidv4();
 	}
-	if (this.passStatus === 'active' && (!this.qrStrings || this.qrStrings.length === 0)) {
+	if (isConfirmed && (!this.qrStrings || this.qrStrings.length === 0)) {
 		this.qrStrings = [];
 		this.qrStrings.push({
 			id: uuidv4(),
 			personType: "user",
 			personIndex: 0,
-			isScanned: false,
+			personName: "Main User",
+			qrScanned: false,
 			scannedAt: null
 		});
 		
@@ -142,7 +165,9 @@ passSchema.pre('save', function(next) {
 			this.qrStrings.push({
 				id: uuidv4(),
 				personType: "friend",
-				isScanned: false,
+				personIndex: i + 1,
+				personName: this.friends[i]?.name || `Friend ${i + 1}`,
+				qrScanned: false,
 				scannedAt: null
 			});
 		}
@@ -155,30 +180,25 @@ passSchema.methods.getQRData = function() {
 	return this.qrStrings.map(qr => ({
 		id: qr.id,
 		personType: qr.personType,
-		personName: qr.personName,
 		personName: qr.personType === "user" ? "Main User" : 
 					this.friends[qr.personIndex - 1]?.name || `Friend ${qr.personIndex}`,
-		isScanned: qr.isScanned,
+		qrScanned: qr.qrScanned,
 		scannedAt: qr.scannedAt,
 		qrContent: `${this.eventId}_${this.passUUID}_${qr.id}_${qr.personName}`
 	}));
 };
 
 passSchema.methods.markQRScanned = function(qrId) {
-	let flag= true;
-	const qrString = this.qrStrings.find(qr => qr.id === qrId);
-	if (qrString && !qrString.isScanned) {
-		qrString.isScanned = true;
+	const qrString = this.qrStrings.find(qr => qr.id === qrId || qr._id?.toString() === qrId);
+	if (qrString && !qrString.qrScanned) {
+		qrString.qrScanned = true;
 		qrString.scannedAt = new Date();
-		for (let i = 0; i < this.qrStrings.length; i++) {
-			if (this.qrStrings[qrScanned]==false) {
-				flag = false;
-				break;}
 
-		if (!this.isScanned && flag) {
+		const allScanned = this.qrStrings.every(qr => qr.qrScanned);
+		if (!this.isScanned && allScanned) {
 			this.isScanned = true;
 			this.timeScanned = new Date();
-		}}
+		}
 		
 		return this.save();
 	}
@@ -186,15 +206,18 @@ passSchema.methods.markQRScanned = function(qrId) {
 };
 
 passSchema.statics.validateQRString = async function(qrId) {
-	const pass = await this.findOne({ "qrStrings.id": qrId });
+	const query = mongoose.Types.ObjectId.isValid(qrId)
+		? { $or: [{ "qrStrings._id": qrId }, { "qrStrings.id": qrId }] }
+		: { "qrStrings.id": qrId };
+	const pass = await this.findOne(query);
 	if (!pass) {
 		return { valid: false, message: "Invalid QR code" };
 	}
-	const qrString = pass.qrStrings.find(qr => qr.id === qrId);
-	if (qrString.isScanned) {
+	const qrString = pass.qrStrings.find(qr => qr.id === qrId || qr._id?.toString() === qrId);
+	if (qrString.qrScanned) {
 		return { valid: false, message: "QR code already scanned" };
 	}
-	if (pass.passStatus !== 'active') {
+	if (pass.paymentStatus !== 'completed' || (pass.status && pass.status !== 'active')) {
 		return { valid: false, message: "Pass is not active" };
 	}
 	return { valid: true, pass, qrString };

--- a/Server/src/routes/router.js
+++ b/Server/src/routes/router.js
@@ -10,6 +10,16 @@ router.get(
   "/api/payment/callback/:merchantOrderId",
   Passes.handlePaymentCallback,
 );
+router.post(
+  "/api/payment/webhook",
+  express.raw({ type: "application/json" }),
+  Passes.handlePaymentWebhook,
+);
+router.post(
+  "/payment/webhook",
+  express.raw({ type: "application/json" }),
+  Passes.handlePaymentWebhook,
+);
 router.use((req, res, next) => {
   const csp = [
     "default-src 'self'",
@@ -45,11 +55,6 @@ router.use(auth.verifyToken);
 router.post("/register", influencerValidation, Events.registerForInfluencer);
 
 router.post("/api/book-ticket", Passes.bookTicket);
-router.post(
-  "/payment/webhook",
-  express.raw({ type: "application/json" }), // For webhook raw body handling
-  Passes.handlePaymentWebhook,
-);
 router.get("/api/passbyuuid/:passUUID", Passes.getPassByUUID);
 router.post("/api/getTix", Passes.getPassByQrStringsAndPassUUID);
 // Event Interaction Routes

--- a/Server/test/payment-logic.test.js
+++ b/Server/test/payment-logic.test.js
@@ -1,0 +1,96 @@
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const test = require("node:test");
+
+const { _test } = require("../src/controllers/passes.controller");
+
+test("PhonePe test credentials default to sandbox endpoints", () => {
+  const previousEnv = process.env.PHONEPE_ENV;
+  const previousClientId = process.env.PHONEPE_CLIENT_ID;
+
+  delete process.env.PHONEPE_ENV;
+  process.env.PHONEPE_CLIENT_ID = "TEST-client-id";
+
+  assert.equal(
+    _test.getPhonePeConfig().BASE_URL,
+    "https://api-preprod.phonepe.com/apis/pg-sandbox",
+  );
+
+  process.env.PHONEPE_ENV = previousEnv;
+  process.env.PHONEPE_CLIENT_ID = previousClientId;
+});
+
+test("explicit production PhonePe env uses production endpoints without whitespace", () => {
+  const previousEnv = process.env.PHONEPE_ENV;
+
+  process.env.PHONEPE_ENV = "production";
+
+  assert.equal(
+    _test.getPhonePeConfig().BASE_URL,
+    "https://api.phonepe.com/apis/pg",
+  );
+
+  process.env.PHONEPE_ENV = previousEnv;
+});
+
+test("friend list is capped and normalized", () => {
+  const friends = Array.from({ length: 12 }, (_, index) => ({
+    name: index === 0 ? "" : `Friend ${index}`,
+    email: `friend${index}@example.com`,
+  }));
+
+  const sanitized = _test.sanitizeFriends(friends);
+
+  assert.equal(sanitized.length, 9);
+  assert.equal(sanitized[0].name, "Friend");
+  assert.equal(sanitized[8].email, "friend8@example.com");
+});
+
+test("QR strings are generated for buyer and friends as unscanned entries", () => {
+  const qrStrings = _test.buildQRStrings(
+    { name: "Buyer" },
+    [{ name: "A" }, { name: "B" }],
+  );
+
+  assert.equal(qrStrings.length, 3);
+  assert.equal(qrStrings[0].personName, "Buyer");
+  assert.equal(qrStrings[1].personType, "friend");
+  assert.equal(qrStrings[2].qrScanned, false);
+  assert.match(qrStrings[0].id, /^[0-9a-f-]{36}$/);
+});
+
+test("PhonePe status normalizer supports wrapped and top-level responses", () => {
+  assert.deepEqual(
+    _test.normalizePhonePeStatus({
+      data: { state: "COMPLETED", orderId: "order-1", amount: 1000 },
+    }),
+    {
+      state: "COMPLETED",
+      orderId: "order-1",
+      amount: 1000,
+      paymentDetails: [],
+      reason: undefined,
+    },
+  );
+
+  assert.equal(
+    _test.normalizePhonePeStatus({ state: "FAILED", reason: "DECLINED" }).reason,
+    "DECLINED",
+  );
+});
+
+test("webhook signature uses SHA256 username:password", () => {
+  const signature = crypto
+    .createHash("sha256")
+    .update("ritesh:ritesh123")
+    .digest("hex");
+
+  assert.equal(
+    _test.validateWebhookSignature("ritesh", "ritesh123", signature),
+    true,
+  );
+  assert.equal(
+    _test.validateWebhookSignature("ritesh", "ritesh123", "bad-signature"),
+    false,
+  );
+});


### PR DESCRIPTION
-PhonePe TEST credentials now use sandbox/preprod endpoints instead of production.
-Removed hidden tab/whitespace bug in PhonePe base URL.
-Webhook routes are now public, not blocked behind JWT auth.
-Added /api/payment/webhook plus existing /payment/webhook.
-Paid ticket booking now reserves seats using registrationCount.
-Failed/expired payment releases reserved seats.
-Free/zero-price passes no longer try to create a PhonePe payment.
-Pending paid passes no longer generate usable QR/pass UUID before payment completion.
-QR duplicate scan bug fixed: code was checking isScanned, but schema uses qrScanned.
-Pass scan now requires completed payment.
-Fixed admin revenue/pass count logic that had hard-coded subtraction.
-Fixed old /paymentTesting page to call /api/book-ticket, not missing /payment.