### PR TITLE
Jatin team registration event booking fixes

### DIFF
--- a/Client/next.config.mjs
+++ b/Client/next.config.mjs
@@ -17,6 +17,8 @@ const nextConfig = {
 	},
 	env: {
 		BACKEND_URL: process.env.BACKEND_URL,
+		GOOGLE_CLIENT_ID:
+			process.env.GOOGLE_CLIENT_ID || process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
 	},
 	images: {
 		domains: ["res.cloudinary.com", "api.dicebear.com"],

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -86,13 +86,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -152,16 +152,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@babel/types": "^7.27.3",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
@@ -302,6 +302,16 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
@@ -317,29 +327,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -362,9 +372,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -422,9 +432,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -432,9 +442,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -481,13 +491,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.7.tgz",
-      "integrity": "sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.7"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1079,16 +1089,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
-      "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1769,48 +1779,48 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.7.tgz",
-      "integrity": "sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.27.5",
-        "@babel/parser": "^7.27.7",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.27.7",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.7.tgz",
-      "integrity": "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2456,32 +2466,19 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2494,9 +2491,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2504,9 +2501,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -2547,9 +2544,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.16.tgz",
-      "integrity": "sha512-noORwKUMkKc96MWjTOwrsUCjky0oFegHbeJ1yEnQBGbMHAaTEIgLZIIfsYF0x3a06PiS+2TXppfifR+O6VWslg==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
+      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5435,16 +5432,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -6685,9 +6672,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -7830,13 +7817,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.16.tgz",
-      "integrity": "sha512-HOcnCJsyLXR7B8wmjaCgkTSpz+ijgOyAkP8OlvANvciP8PspBYFEBTmakNMxOf71fY0aKOm/blFIiKnrM4K03Q==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
+      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.16",
+        "@next/eslint-plugin-next": "14.2.35",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -8727,9 +8714,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -9508,9 +9496,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9780,12 +9768,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9814,14 +9802,14 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
+        "@mongodb-js/saslprep": "^1.3.0",
         "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.0"
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -9832,7 +9820,7 @@
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "snappy": "^7.3.2",
         "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
@@ -9870,14 +9858,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.1.tgz",
-      "integrity": "sha512-Q+0TC+KLdY4SYE+u9gk9pdW1tWu/pl0jusyEkMGTgBoAbvwQdfy4f9IM8dmvCwb/blSfp7IfLkob7v76x6ZGpQ==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
+      "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
-        "mongodb": "~6.17.0",
+        "mongodb": "~6.20.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -9954,9 +9942,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -10475,9 +10463,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -10515,9 +10503,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10534,8 +10522,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -11209,6 +11197,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -11841,19 +11839,19 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
         "css-select": "^5.1.0",
         "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.0",
+        "sax": "^1.5.0"
       },
       "bin": {
         "svgo": "bin/svgo"
@@ -11877,9 +11875,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "11.1.14",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.14.tgz",
-      "integrity": "sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==",
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
       "funding": [
         {
           "type": "patreon",
@@ -12740,15 +12738,18 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/Client/src/app/createEvent/page.tsx
+++ b/Client/src/app/createEvent/page.tsx
@@ -170,11 +170,25 @@ export default function CreateEventPage() {
     setLoading(true);
     try {
       const token = localStorage.getItem("accessToken");
-      await fetch(`http://localhost:3001/event/create`, {
+      const endpoint =
+        process.env.NEXT_PUBLIC_EVENT_CREATE_URL ||
+        (process.env.BACKEND_URL
+          ? `${process.env.BACKEND_URL}/dashboard/create-event`
+          : "");
+      if (!endpoint) {
+        throw new Error("Event creation endpoint is not configured");
+      }
+      const response = await fetch(endpoint, {
         method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify(data),
       });
+      if (!response.ok) {
+        throw new Error(`Event creation failed with status ${response.status}`);
+      }
       alert("Event created successfully!");
     } catch {
       alert("Event creation failed!");

--- a/Client/src/app/dashboard/registered/page.tsx
+++ b/Client/src/app/dashboard/registered/page.tsx
@@ -12,7 +12,11 @@ export default function RegisteredEvents() {
   useEffect(() => {
     (async () => {
       try {
-        const res   = await fetch("https://api.talkeys.xyz/getEvents");
+        if (!process.env.BACKEND_URL) {
+          throw new Error("BACKEND_URL is not configured");
+        }
+
+        const res   = await fetch(`${process.env.BACKEND_URL}/getEvents`);
         const json  = await res.json() as {
           data: { events: Event[] };
         };

--- a/Client/src/app/page.tsx
+++ b/Client/src/app/page.tsx
@@ -14,6 +14,7 @@ export default function Home() {
   const [upcomingEvents, setUpcomingEvents] = useState<Event[]>([]);
   const [pastEvents, setPastEvents] = useState<Event[]>([]);
   const [loading, setLoading] = useState(true);
+  const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -46,7 +47,7 @@ export default function Home() {
   }, []);
 
   return (
-    <GoogleOAuthProvider clientId="563385258779-75kq583ov98fk7h3dqp5em0639769a61.apps.googleusercontent.com">
+    <GoogleOAuthProvider clientId={googleClientId}>
       <Hero />
 
       {!loading && upcomingEvents.length > 0 && (

--- a/Client/src/app/paymentTesting/page.tsx
+++ b/Client/src/app/paymentTesting/page.tsx
@@ -4,16 +4,27 @@ import React, { useState } from "react";
 
 const startPayment = async (bookingId: string) => {
     try {
-        const response = await fetch(`${process.env.BACKEND_URL}/payment?eventId=${bookingId}`, {
+        const response = await fetch(`${process.env.BACKEND_URL}/api/book-ticket`, {
             method: "POST",
             headers: {
+                "Content-Type": "application/json",
                 Authorization: `Bearer ${localStorage.getItem(
                     "accessToken",
                 )}`,
             },
+            body: JSON.stringify({
+                eventId: bookingId,
+                passType: "General",
+                friends: [],
+            }),
         });
         if (response.ok) {
-            console.log("Payment started successfully");
+            const data = await response.json();
+            if (data.data?.paymentUrl) {
+                window.location.href = data.data.paymentUrl;
+                return;
+            }
+            console.log("Pass created successfully");
         } else {
             console.error("Failed to start payment");
         }

--- a/Client/src/app/register/page.tsx
+++ b/Client/src/app/register/page.tsx
@@ -1,29 +1,22 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { motion } from "framer-motion";
-import { Users, Globe2, Phone, Lightbulb, FileText, ArrowUpRight, Mail } from "lucide-react";
+import { Users, Phone, ArrowUpRight, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 const BACKEND_URL = process.env.BACKEND_URL;
 
 
-type Member = {
+type FormData = {
   name: string;
   email: string;
-  college: string;
-};
-
-type FormData = {
-  teamName: string;
-  domain: string;
-  members: Member[];
-  projectTitle: string;
-  projectDescription: string;
-  contactEmail: string;
-  contactPhone?: string;
+  phone: string;
+  instaId: string;
+  followersCount: number;
+  attendance: "yes" | "no";
 };
 
 const containerVariants = {
@@ -52,7 +45,6 @@ const itemVariants = {
 
 export default function RegisterPage() {
 	const [loading, setLoading] = useState(false);
-	console.log("Backend URL:", BACKEND_URL);
 
   const {
     register,
@@ -60,27 +52,36 @@ export default function RegisterPage() {
     formState: { errors },
   } = useForm<FormData>({
     defaultValues: {
-      teamName: "",
-      domain: "",
-      members: [],
-      projectTitle: "",
-      projectDescription: "",
-      contactEmail: "",
-      contactPhone: "",
+      name: "",
+      email: "",
+      phone: "",
+      instaId: "",
+      followersCount: 0,
+      attendance: "yes",
     },
   });
 
   const onSubmit = async (data: FormData) => {
     setLoading(true);
     try {
+      if (!BACKEND_URL) {
+        throw new Error("BACKEND_URL is not configured");
+      }
+
       const token = localStorage.getItem("accessToken");
-      const response = await fetch(`https://api.talkeys.xyz/register`, {
+      const response = await fetch(`${BACKEND_URL}/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(data),
+        body: JSON.stringify({
+          name: data.name,
+          instaId: data.instaId,
+          phone: data.phone,
+          followersCount: Number(data.followersCount),
+          attendance: data.attendance,
+        }),
       });
       if (!response.ok) {
         throw new Error(`Request failed with status ${response.status}`);
@@ -128,9 +129,9 @@ export default function RegisterPage() {
             <Input
               className="bg-gray-700 text-white w-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
               placeholder="Enter your name"
-              {...register("teamName", { required: "Name is required" })}
+              {...register("name", { required: "Name is required" })}
             />
-            {errors.teamName && <p className="text-red-500 text-sm mt-1">{errors.teamName.message}</p>}
+            {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name.message}</p>}
           </motion.div>
 
           <motion.div variants={itemVariants}>
@@ -141,7 +142,7 @@ export default function RegisterPage() {
             <Input
               className="bg-gray-700 text-white w-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
               placeholder="you@gmail.com"
-              {...register("contactEmail", {
+              {...register("email", {
                 required: "Email is required",
                 pattern: {
                   value: /^[^@ ]+@[^@ ]+\.[^@ .]{2,}$/,
@@ -149,7 +150,41 @@ export default function RegisterPage() {
                 },
               })}
             />
-            {errors.domain && <p className="text-red-500 text-sm mt-1">{errors.domain.message}</p>}
+            {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email.message}</p>}
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
+            <label className="block mb-1 text-gray-300 flex items-center gap-2">
+              <Users className="w-4 h-4 text-purple-400" />
+              Instagram ID
+            </label>
+            <Input
+              className="bg-gray-700 text-white w-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              placeholder="@yourhandle"
+              {...register("instaId", { required: "Instagram ID is required" })}
+            />
+            {errors.instaId && <p className="text-red-500 text-sm mt-1">{errors.instaId.message}</p>}
+          </motion.div>
+
+          <motion.div variants={itemVariants}>
+            <label className="block mb-1 text-gray-300 flex items-center gap-2">
+              <Users className="w-4 h-4 text-purple-400" />
+              Followers Count
+            </label>
+            <Input
+              type="number"
+              className="bg-gray-700 text-white w-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              placeholder="5000"
+              {...register("followersCount", {
+                required: "Followers count is required",
+                min: {
+                  value: 5000,
+                  message: "Followers count must be at least 5000",
+                },
+                valueAsNumber: true,
+              })}
+            />
+            {errors.followersCount && <p className="text-red-500 text-sm mt-1">{errors.followersCount.message}</p>}
           </motion.div>
 
           <motion.div variants={itemVariants}>
@@ -160,12 +195,29 @@ export default function RegisterPage() {
             <Input
               className="bg-gray-700 text-white w-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
               placeholder="Enter phone number"
-              {...register("contactPhone", { required: "Phone number is required" })}
+              {...register("phone", {
+                required: "Phone number is required",
+                pattern: {
+                  value: /^(\+91)?\d{10}$/,
+                  message: "Enter a valid 10 digit phone number",
+                },
+              })}
             />
-            {errors.contactPhone && <p className="text-red-500 text-sm mt-1">{errors.contactPhone.message}</p>}
+            {errors.phone && <p className="text-red-500 text-sm mt-1">{errors.phone.message}</p>}
           </motion.div>
 
-          
+          <motion.div variants={itemVariants}>
+            <label className="block mb-1 text-gray-300">
+              Will you attend?
+            </label>
+            <select
+              className="bg-gray-700 text-white w-full rounded-md px-3 py-2 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              {...register("attendance", { required: true })}
+            >
+              <option value="yes">Yes</option>
+              <option value="no">No</option>
+            </select>
+          </motion.div>
           
 
           <motion.div variants={itemVariants}>

--- a/Client/src/app/sign/page.tsx
+++ b/Client/src/app/sign/page.tsx
@@ -16,11 +16,12 @@ import { useRouter } from "next/navigation";
 const SignUpPage = () => {
 	const router = useRouter();
 	const { isSignedIn, setIsSignedIn } = useAuth();
+	const googleClientId = process.env.GOOGLE_CLIENT_ID || "";
 
 	useEffect(() => {
 		const token = localStorage.getItem("accessToken");
 		setIsSignedIn(!!token);
-	}, []);
+	}, [setIsSignedIn]);
 
 	const handleLogout = () => {
 		localStorage.removeItem("accessToken");
@@ -30,7 +31,7 @@ const SignUpPage = () => {
 	};
 
 	return (
-		<GoogleOAuthProvider clientId="563385258779-75kq583ov98fk7h3dqp5em0639769a61.apps.googleusercontent.com">
+		<GoogleOAuthProvider clientId={googleClientId}>
 			<motion.div
 				className="min-h-screen text-white"
 				style={{

--- a/Client/src/components/EventCarousel.tsx
+++ b/Client/src/components/EventCarousel.tsx
@@ -39,6 +39,8 @@ export function formatTime(timeString: string): string {
 
 const EventCard = memo(function EventCard({ event, index }: EventCardProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const convenienceFee = Number(process.env.NEXT_PUBLIC_CONVENIENCE_FEE || 0);
+  const displayedPrice = Math.max(Number(event.ticketPrice || 0) - convenienceFee, 0);
 
   return (
     <motion.div
@@ -117,10 +119,7 @@ const EventCard = memo(function EventCard({ event, index }: EventCardProps) {
                 {/* footer row */}
                 <div className="mt-auto flex gap-2 sm:gap-4 mb-2">
                   <div className="text-gray-400 border border-[#DCB6FF] rounded-3xl pt-1 pb-1 px-2 sm:px-3 text-xs sm:text-sm">
-                    ₹{" "}
-                    {event._id == "6941834009f38cd886cb1aa0"
-                      ? "300"
-                      : event.ticketPrice - 9}
+                    ₹ {displayedPrice}
                   </div>
                   <div className="text-gray-400 border border-[#DCB6FF] rounded-3xl pt-1 pb-1 px-2 sm:px-3 text-xs sm:text-sm truncate">
                     {event.category ?? "--"}

--- a/Client/src/components/Events/EventHeader.tsx
+++ b/Client/src/components/Events/EventHeader.tsx
@@ -28,6 +28,13 @@ export default function EventHeader({
   onClose,
   children,
 }: HeaderProps) {
+  const convenienceFee = Number(process.env.NEXT_PUBLIC_CONVENIENCE_FEE || 0);
+  const basicPassRequiredEventId =
+    process.env.NEXT_PUBLIC_BASIC_PASS_REQUIRED_EVENT_ID;
+  const requiresBasicPass =
+    Boolean(basicPassRequiredEventId) && event._id === basicPassRequiredEventId;
+  const displayedPrice = Math.max(Number(event.ticketPrice || 0) - convenienceFee, 0);
+
   return (
     <>
       {onClose && (
@@ -104,7 +111,7 @@ export default function EventHeader({
           </div>
 
           {/* Requirement Banner (Only for specific Event ID) */}
-          {event._id === "6941834009f38cd886cb1aa0" && (
+          {requiresBasicPass && (
             <div className="w-full p-3 bg-purple-900/20 border border-[#CCA1F4]/30 rounded-xl text-left">
               <p className="text-[#CCA1F4] text-xs sm:text-sm font-urbanist">
                 <span className="font-bold text-white">Requirement:</span> To
@@ -114,48 +121,48 @@ export default function EventHeader({
                 </span>
                 .
               </p>
-              <p className="text-[#CCA1F4] text-[10px] sm:text-xs mt-1">
-                * After purchase, the price will drop to ₹ 200.
-              </p>
             </div>
           )}
 
           {/* Price and Likes Section */}
           <div className="flex justify-between items-center gap-2 w-full">
             <span className="text-white text-base sm:text-lg font-bold font-urbanist flex items-center gap-2">
-              {event._id === "6941834009f38cd886cb1aa0" ? (
-                <>
-                  <span className="text-gray-400 line-through font-normal text-sm sm:text-base">
-                    ₹ 300
-                  </span>
-                  <span>₹ 200</span>
-                </>
-              ) : (
-                <span>₹ {event.ticketPrice - 9}</span>
-              )}
+              <span>₹ {displayedPrice}</span>
 
-              <span className="font-normal text-xs sm:text-sm opacity-80">
-                (excl. ₹ 9 Convenience Fee)
-              </span>
+              {convenienceFee > 0 && (
+                <span className="font-normal text-xs sm:text-sm opacity-80">
+                  (excl. ₹ {convenienceFee} Convenience Fee)
+                </span>
+              )}
             </span>
 
             <div className="flex items-center gap-2">
               <div className="flex items-center gap-2">
-                <motion.img
-                  src={heartImg.src}
-                  alt="likes"
-                  className="w-12 h-5 object-contain cursor-pointer transition-transform hover:scale-105"
+                <motion.button
+                  type="button"
                   onClick={toggleLike}
+                  className="cursor-pointer transition-transform hover:scale-105"
+                  aria-label={isLike ? "Unlike event" : "Like event"}
                   animate={{ scale: isLike ? 1.1 : 1 }}
                   transition={{
                     type: "spring",
                     stiffness: 300,
                     damping: 12,
                   }}
-                />
-                <img
-                  src={vectorImg.src}
+                >
+                  <Image
+                    src={heartImg}
+                    alt=""
+                    width={48}
+                    height={20}
+                    className="w-12 h-5 object-contain"
+                  />
+                </motion.button>
+                <Image
+                  src={vectorImg}
                   alt="vector"
+                  width={24}
+                  height={24}
                   className="w-6 h-6 object-contain"
                 />
               </div>

--- a/Client/src/components/Events/ParticularEventPage.tsx
+++ b/Client/src/components/Events/ParticularEventPage.tsx
@@ -91,14 +91,26 @@ export default function ParticularEventPage({
     if (passQRCodes.length) setState("passCreated");
   }, [passQRCodes.length, setState]);
 
-  const handleRegisterClick = () => {
+  const handleRegisterClick = async () => {
     if (event.registrationLink) window.open(event.registrationLink, "_blank");
-    else router.push("/register");
+    else await handleCreatePass();
   };
 
   async function handleCreatePass() {
-    await createPass(teamCode);
-    setState("passCreated");
+    if (!isSignedIn) {
+      toast.error("Please log in first to register.");
+      return;
+    }
+    try {
+      if (event.isPaid) {
+        await handlePayNowClick();
+        return;
+      }
+      await createPass(teamCode);
+      setState("passCreated");
+    } catch (e: any) {
+      toast.error(e?.error ?? "Failed to create pass");
+    }
   }
 
   async function handlePayNowClick() {
@@ -111,6 +123,7 @@ export default function ParticularEventPage({
         eventId: event._id,
         passType: "General",
         friends,
+        teamCode: event.isTeamEvent ? teamCode : undefined,
       });
       // clear friend form after redirect-init
       window.location.href = res.data.paymentUrl;
@@ -122,6 +135,11 @@ export default function ParticularEventPage({
 
   // hover tabs (kept from your UI)
   const [hovered, setHovered] = useState<string | null>(null);
+  const tabs: Array<[string, string]> = [
+    ["details", "DETAILS"],
+    ...(event.prizes ? ([["prizes", "PRIZES"]] as Array<[string, string]>) : []),
+    ["community", "JOIN DISCUSSION COMMUNITY"],
+  ];
 
   return (
     <>
@@ -140,6 +158,7 @@ export default function ParticularEventPage({
           <RegistrationControls
             state={state}
             isPaid={!!event.isPaid}
+            isTeamEvent={!!event.isTeamEvent}
             ticketPrice={event.ticketPrice}
             status={event.status}
             isRegistrationOpen={event.isRegistrationOpen}
@@ -152,6 +171,7 @@ export default function ParticularEventPage({
             setTeamName={setTeamName}
             toJoin={toJoin}
             toCreate={toCreate}
+            startTeamRegistration={() => setState("teamOptions")}
             submitPhone={submitPhone}
             submitJoin={submitJoin}
             submitCreate={submitCreate}
@@ -191,13 +211,7 @@ export default function ParticularEventPage({
         {/* Tabs */}
         <div className="w-max max-w-full bg-[#262626] overflow-x-auto whitespace-nowrap no-scrollbar inline-flex items-center justify-start gap-[8px] sm:gap-[20px] px-3 sm:px-6 mt-6 sm:ml-6">
           <div className="inline-flex items-center gap-[8px] sm:gap-[16px] min-w-max">
-            {["details", "dates", "prizes", "community"].map((key, index) => {
-              const labels = [
-                "DETAILS",
-                // "DATE & DEADLINES",
-                // "PRIZES",
-                "JOIN DISCUSSION COMMUNITY",
-              ];
+            {tabs.map(([key, label]) => {
               return (
                 <button
                   key={key}
@@ -207,7 +221,7 @@ export default function ParticularEventPage({
                     hovered === key ? "bg-[#8A44CB]/30 rounded-md" : ""
                   }`}
                 >
-                  {labels[index]}
+                  {label}
                 </button>
               );
             })}

--- a/Client/src/components/Events/QRCodeDisplay.tsx
+++ b/Client/src/components/Events/QRCodeDisplay.tsx
@@ -12,7 +12,6 @@ import "swiper/css/pagination";
 type Props = { name: string; codes: string[] };
 
 export default function QRCodeDisplay({ name, codes }: Props) {
-  console.log("QRCodeDisplay", name, codes);
   if (!codes.length) return null;
 
   return (

--- a/Client/src/components/Events/RegistrationControls.tsx
+++ b/Client/src/components/Events/RegistrationControls.tsx
@@ -6,12 +6,12 @@ import { Input } from "@/components/ui/input";
 import { motion } from "framer-motion";
 import { Check, Copy, X } from "lucide-react";
 import { type RegistrationState } from "@/lib/hooks/useTeamRegistration";
-import FriendsSection from "./FriendsSection";
 import { type Friend } from "@/lib/utils/validation";
 
 type CommonProps = {
 	state: RegistrationState;
 	isPaid: boolean;
+	isTeamEvent: boolean;
 	ticketPrice?: number;
 	status: string;
 	isLive?: boolean;
@@ -28,11 +28,12 @@ type CommonProps = {
 	// actions
 	toJoin: () => void;
 	toCreate: () => void;
+	startTeamRegistration: () => void;
 	submitPhone: () => void;
 	submitJoin: () => void;
 	submitCreate: () => void;
 	createPass: () => Promise<void> | void;
-	goRegister: () => void;
+	goRegister: () => Promise<void> | void;
 	payNow: () => void;
 	reset: () => void;
 
@@ -72,7 +73,9 @@ export default function RegistrationControls(props: CommonProps) {
 			: props.status === "coming_soon"
 			? "Coming Soon"
 			: props.status === "live"
-			? props.isPaid
+			? props.isTeamEvent
+				? "Register Team"
+				: props.isPaid
 				? "Pay Now"
 				: "Register Now"
 			: "Event Ended";
@@ -83,7 +86,9 @@ export default function RegistrationControls(props: CommonProps) {
 			: props.status === "coming_soon"
 			? "Event coming soon"
 			: props.status === "live"
-			? props.isPaid
+			? props.isTeamEvent
+				? "Register team for event"
+				: props.isPaid
 				? "Pay for tickets for event"
 				: "Register for event"
 			: "Event ended";
@@ -112,7 +117,11 @@ export default function RegistrationControls(props: CommonProps) {
 			>
 				<Button
 					className="bg-purple-600 hover:bg-purple-700 w-full rounded-full"
-					onClick={props.payNow}
+					onClick={
+						props.isTeamEvent
+							? props.startTeamRegistration
+							: props.payNow
+					}
 					disabled={isDisabled}
 					aria-label={initialAria}
 				>
@@ -134,7 +143,11 @@ export default function RegistrationControls(props: CommonProps) {
 		>
 			<Button
 				className="bg-purple-600 hover:bg-purple-700 w-full"
-				onClick={props.goRegister}
+				onClick={
+					props.isTeamEvent
+						? props.startTeamRegistration
+						: props.goRegister
+				}
 				disabled={isDisabled}
 				aria-label={initialAria}
 			>
@@ -349,7 +362,7 @@ export default function RegistrationControls(props: CommonProps) {
 							className="bg-green-600 hover:bg-green-700 w-full"
 							onClick={() => props.createPass()}
 						>
-							Create Pass
+							{props.isPaid ? "Pay Now" : "Create Pass"}
 						</Button>
 					</motion.div>
 				</div>
@@ -357,36 +370,22 @@ export default function RegistrationControls(props: CommonProps) {
 		case "teamJoined":
 			return (
 				<div className="w-full max-w-sm mx-auto space-y-3">
-					<FriendsSection
-						show={props.showFriends}
-						toggle={() => props.setShowFriends(!props.showFriends)}
-						name={props.name}
-						setName={props.setName}
-						email={props.email}
-						setEmail={props.setEmail}
-						phone={props.phoneFriend}
-						setPhone={props.setPhoneFriend}
-						errors={props.errors}
-						validateField={props.validateField}
-						onEnter={props.onEnter}
-						add={props.addFriend}
-						remove={props.removeFriend}
-						friends={props.friends}
-					/>
+					<div className="text-green-500 text-center">
+						Joined team: {props.teamName}
+					</div>
 					<motion.div
 						whileHover={{ scale: 1.05 }}
 						whileTap={{ scale: 0.95 }}
 					>
 						<Button
 							className="bg-purple-600 hover:bg-purple-700 w-full"
-							onClick={props.payNow}
+							onClick={
+								props.isPaid
+									? props.payNow
+									: () => props.createPass()
+							}
 						>
-							Pay Now
-							{props.friends.length > 0 && (
-								<span className="ml-2 text-xs bg-purple-800 px-2 py-1 rounded-full">
-									+{props.friends.length}
-								</span>
-							)}
+							{props.isPaid ? "Pay Now" : "Create Pass"}
 						</Button>
 					</motion.div>
 				</div>

--- a/Client/src/components/QRScanner.tsx
+++ b/Client/src/components/QRScanner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import QrScanner from "qr-scanner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,6 +31,7 @@ type ScannerState = "scanning" | "passInfo" | "success" | "error" | "used";
 export default function QRScannerComponent() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const qrScannerRef = useRef<QrScanner | null>(null);
+  const isPendingRef = useRef(false);
   const [state, setState] = useState<ScannerState>("scanning");
   const [passInfo, setPassInfo] = useState<GetTixResponse | null>(null);
   const [currentPassId, setCurrentPassId] = useState<CurrentPassId | null>(
@@ -42,44 +43,86 @@ export default function QRScannerComponent() {
     null,
   );
 
-  // Initialize QR Scanner
-  useEffect(() => {
-    if (state === "scanning" && videoRef.current) {
-      initializeScanner();
-    }
-    return () => {
-      if (qrScannerRef.current) {
-        qrScannerRef.current.destroy();
-        qrScannerRef.current = null;
-      }
+  const setPending = useCallback((value: boolean) => {
+    isPendingRef.current = value;
+    setIsPending(value);
+  }, []);
+
+  const parseQRData = useCallback((qrData: string): { passUUID: string; qrId?: string } => {
+    // Assuming the format is "passUUID+qrId" or just "passUUID"
+    const parts = qrData.split("+");
+    return {
+      passUUID: parts[0],
+      qrId: parts[1] || undefined,
     };
-  }, [state]);
+  }, []);
 
-  const initializeScanner = async () => {
-    if (!videoRef.current) return;
-
+  const getPassInfo = useCallback(async (
+    passUUID: string,
+    qrId?: string,
+  ): Promise<void> => {
     try {
-      qrScannerRef.current = new QrScanner(
-        videoRef.current,
-        (result) => handleQRScan(result.data),
-        {
-          highlightScanRegion: true,
-          highlightCodeOutline: true,
-          preferredCamera: "environment",
+      const token = localStorage.getItem("accessToken");
+      if (!token) {
+        throw new Error("No access token found. Please login.");
+      }
+
+      // Prepare request body
+      const requestBody: any = { passUUID };
+      if (qrId) {
+        requestBody.qrId = qrId;
+      }
+
+      const response = await fetch(`${process.env.BACKEND_URL}/api/getTix`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
         },
-      );
-      await qrScannerRef.current.start();
+        body: JSON.stringify(requestBody),
+      });
+
+      if (response.ok) {
+        const data: GetTixResponse = await response.json();
+
+        if (!data.success) {
+          throw new Error("API returned unsuccessful response");
+        }
+
+        setPassInfo(data);
+        setCurrentPassId({ passUUID, qrId });
+        setState("passInfo");
+        setPending(false);
+        setError(null);
+      } else if (response.status === 404) {
+        setVerificationStatus("Invalid Pass");
+        setError("Pass not found. Please check the QR code.");
+        setState("error");
+        setPending(false);
+      } else if (response.status === 401) {
+        setError("Authentication failed. Please login again.");
+        setState("error");
+        setPending(false);
+      } else {
+        const errorText = await response.text();
+        throw new Error(`Server error ${response.status}: ${errorText}`);
+      }
     } catch (error) {
-      console.error("Failed to start QR scanner:", error);
-      setError("Failed to access camera. Please check permissions.");
+      console.error("Error fetching pass info:", error);
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Failed to verify pass. Please try again.",
+      );
       setState("error");
+      setPending(false);
     }
-  };
+  }, [setPending]);
 
-  const handleQRScan = async (qrData: string) => {
-    if (isPending) return;
+  const handleQRScan = useCallback(async (qrData: string) => {
+    if (isPendingRef.current) return;
 
-    setIsPending(true);
+    setPending(true);
     setError(null);
 
     try {
@@ -102,85 +145,43 @@ export default function QRScannerComponent() {
         error instanceof Error ? error.message : "Failed to process QR code",
       );
       setState("error");
-      setIsPending(false);
+      setPending(false);
     }
-  };
+  }, [getPassInfo, parseQRData, setPending]);
 
-  const parseQRData = (qrData: string): { passUUID: string; qrId?: string } => {
-    // Assuming the format is "passUUID+qrId" or just "passUUID"
-    const parts = qrData.split("+");
-    return {
-      passUUID: parts[0],
-      qrId: parts[1] || undefined,
-    };
-  };
-
-  const getPassInfo = async (
-    passUUID: string,
-    qrId?: string,
-  ): Promise<void> => {
-    console.log("Fetching pass info for:", { passUUID, qrId });
+  const initializeScanner = useCallback(async () => {
+    if (!videoRef.current) return;
 
     try {
-      const token = localStorage.getItem("accessToken");
-      if (!token) {
-        throw new Error("No access token found. Please login.");
-      }
-
-      // Prepare request body
-      const requestBody: any = { passUUID };
-      if (qrId) {
-        requestBody.qrId = qrId;
-      }
-
-      const response = await fetch(`${process.env.BACKEND_URL}/api/getTix`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+      qrScannerRef.current = new QrScanner(
+        videoRef.current,
+        (result) => handleQRScan(result.data),
+        {
+          highlightScanRegion: true,
+          highlightCodeOutline: true,
+          preferredCamera: "environment",
         },
-        body: JSON.stringify(requestBody),
-      });
-
-      console.log("Response status:", response.status);
-
-      if (response.ok) {
-        const data: GetTixResponse = await response.json();
-        console.log("Pass data received:", data);
-
-        if (!data.success) {
-          throw new Error("API returned unsuccessful response");
-        }
-
-        setPassInfo(data);
-        setCurrentPassId({ passUUID, qrId });
-        setState("passInfo");
-        setIsPending(false);
-        setError(null);
-      } else if (response.status === 404) {
-        setVerificationStatus("Invalid Pass");
-        setError("Pass not found. Please check the QR code.");
-        setState("error");
-        setIsPending(false);
-      } else if (response.status === 401) {
-        setError("Authentication failed. Please login again.");
-        setState("error");
-        setIsPending(false);
-      } else {
-        const errorText = await response.text();
-        throw new Error(`Server error ${response.status}: ${errorText}`);
-      }
-    } catch (error) {
-      console.error("Error fetching pass info:", error);
-      setError(
-        error instanceof Error
-          ? error.message
-          : "Failed to verify pass. Please try again.",
       );
+      await qrScannerRef.current.start();
+    } catch (error) {
+      console.error("Failed to start QR scanner:", error);
+      setError("Failed to access camera. Please check permissions.");
       setState("error");
-      setIsPending(false);
     }
-  };
+  }, [handleQRScan]);
+
+  // Initialize QR Scanner
+  useEffect(() => {
+    if (state === "scanning" && videoRef.current) {
+      initializeScanner();
+    }
+    return () => {
+      if (qrScannerRef.current) {
+        qrScannerRef.current.destroy();
+        qrScannerRef.current = null;
+      }
+    };
+  }, [initializeScanner, state]);
 
   const handleAccept = async () => {
     if (!currentPassId || !passInfo) {
@@ -188,15 +189,13 @@ export default function QRScannerComponent() {
       return;
     }
 
-    setIsPending(true);
+    setPending(true);
 
     try {
       const token = localStorage.getItem("accessToken");
       if (!token) {
         throw new Error("No access token found");
       }
-
-      console.log("Accepting pass:", currentPassId.passUUID);
 
       const response = await fetch(`${process.env.BACKEND_URL}/Accept`, {
         method: "POST",
@@ -211,7 +210,6 @@ export default function QRScannerComponent() {
       });
 
       if (response.ok) {
-        console.log("Pass accepted successfully");
         // Update the pass info to reflect it's now scanned
         const currentTime = new Date().toISOString();
         setPassInfo({
@@ -237,7 +235,7 @@ export default function QRScannerComponent() {
       );
       setState("error");
     } finally {
-      setIsPending(false);
+      setPending(false);
     }
   };
 
@@ -250,7 +248,7 @@ export default function QRScannerComponent() {
     setCurrentPassId(null);
     setError(null);
     setVerificationStatus(null);
-    setIsPending(false);
+    setPending(false);
     setState("scanning");
   };
 

--- a/Client/src/components/admin/AddEventPage.tsx
+++ b/Client/src/components/admin/AddEventPage.tsx
@@ -25,6 +25,9 @@ import {
 } from "@/components/ui/card";
 import type { FormData } from "@/types/types";
 
+const CLOUDINARY_CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+const CLOUDINARY_UPLOAD_PRESET = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET;
+
 const AddEventPage: React.FC = () => {
 	const {
 		control,
@@ -68,16 +71,19 @@ const AddEventPage: React.FC = () => {
 	const onSubmit = async (data: FormData) => {
 		const uploadToCloudinary = async (files: FileList | null) => {
 			if (!files) return [];
+			if (!CLOUDINARY_CLOUD_NAME || !CLOUDINARY_UPLOAD_PRESET) {
+				throw new Error("Cloudinary upload configuration is missing");
+			}
 			const uploadedFiles: string[] = [];
 
 			for (const file of Array.from(files)) {
 				const formData = new FormData();
 				formData.append("file", file);
-				formData.append("upload_preset", "talkeys");
+				formData.append("upload_preset", CLOUDINARY_UPLOAD_PRESET);
 
 				try {
 					const response = await fetch(
-						`https://api.cloudinary.com/v1_1/drvoynt07/image/upload`,
+						`https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/image/upload`,
 						{
 							method: "POST",
 							body: formData,

--- a/Client/src/components/admin/layout-mobile-nav.tsx
+++ b/Client/src/components/admin/layout-mobile-nav.tsx
@@ -22,7 +22,7 @@ const MobileNav: React.FC<MobileNavProps> = ({ isOpen, onToggle }) => {
 		if (isOpen) {
 			onToggle();
 		}
-	}, [pathname]);
+	}, [isOpen, onToggle, pathname]);
 
 	const navItems = [
 		{ href: "/admin", icon: LayoutDashboard, label: "Dashboard" },

--- a/Client/src/components/dashboard/UserProfileForm.tsx
+++ b/Client/src/components/dashboard/UserProfileForm.tsx
@@ -8,8 +8,7 @@
      user: { displayName?: string; about?: string };
      mutate: () => void;
    }
-   
-   const API = "http://localhost:8000";
+   const API = process.env.BACKEND_URL;
    
    export default function UserProfileForm({ user, mutate }: Props) {
      const [displayName, setDisplayName] = useState(user.displayName || "");
@@ -18,10 +17,13 @@
    
      const nameInputRef = useRef<HTMLInputElement>(null);
    
-     async function save() {
-       setStatus("saving");
-   
-       const res = await fetch(`${API}/dashboard/profile`, {
+   async function save() {
+     setStatus("saving");
+     if (!API) {
+       setStatus("err");
+       return;
+     }
+     const res = await fetch(`${API}/dashboard/profile`, {
          method: "PATCH",
          headers: {
            "Content-Type": "application/json",
@@ -73,7 +75,7 @@
              className="w-full bg-gray-800 border border-gray-700 rounded p-2 text-white"
            />
          </div>
-   
+
          {/* About */}
          <div>
            <label className="block mb-1 text-sm text-gray-300">About</label>
@@ -91,4 +93,3 @@
        </div>
      );
    }
-   

--- a/Client/src/components/ui/3d-card.tsx
+++ b/Client/src/components/ui/3d-card.tsx
@@ -125,17 +125,21 @@ export const CardItem = ({
 	const [isMouseEntered] = useMouseEnter();
 
 	useEffect(() => {
-		handleAnimations();
-	}, [isMouseEntered]);
-
-	const handleAnimations = () => {
 		if (!ref.current) return;
 		if (isMouseEntered) {
 			ref.current.style.transform = `translateX(${translateX}px) translateY(${translateY}px) translateZ(${translateZ}px) rotateX(${rotateX}deg) rotateY(${rotateY}deg) rotateZ(${rotateZ}deg)`;
 		} else {
 			ref.current.style.transform = `translateX(0px) translateY(0px) translateZ(0px) rotateX(0deg) rotateY(0deg) rotateZ(0deg)`;
 		}
-	};
+	}, [
+		isMouseEntered,
+		rotateX,
+		rotateY,
+		rotateZ,
+		translateX,
+		translateY,
+		translateZ,
+	]);
 
 	return (
 		<Tag

--- a/Client/src/lib/hooks/usePassManagement.ts
+++ b/Client/src/lib/hooks/usePassManagement.ts
@@ -1,12 +1,12 @@
 // hooks/usePassManagement.ts
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { bookPass, getPass } from "@/lib/services/eventApi";
 
 export function usePassManagement(eventId: string) {
   const [codes, setCodes] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
 
-  async function refresh() {
+  const refresh = useCallback(async () => {
     try {
       const data = await getPass(eventId);
       const qrs: string[] = [];
@@ -23,11 +23,11 @@ export function usePassManagement(eventId: string) {
     } catch {
       setCodes([]);
     }
-  }
+  }, [eventId]);
 
   useEffect(() => {
     refresh();
-  }, [eventId]);
+  }, [refresh]);
 
   async function create(teamCode: string) {
     setLoading(true);

--- a/Client/src/lib/hooks/useTeamRegistration.ts
+++ b/Client/src/lib/hooks/useTeamRegistration.ts
@@ -41,6 +41,7 @@ export function useTeamRegistration(eventId: string) {
 		} catch (e: any) {
 			if (e?.status === 400)
 				setErrorMsg("Team full or invalid phone number");
+			else if (e?.status === 403) setErrorMsg("Login before joining a team");
 			else if (e?.status === 404) setErrorMsg("Team or user not found");
 			else setErrorMsg("Server error");
 			setState("error");
@@ -63,7 +64,8 @@ export function useTeamRegistration(eventId: string) {
 			setState("createTeamCode");
 		} catch (e: any) {
 			if (e?.status === 400) setErrorMsg("Invalid phone number");
-			else if (e?.status === 401) setErrorMsg("Login Before Creating Team");
+			else if (e?.status === 401 || e?.status === 403)
+				setErrorMsg("Login before creating a team");
 			else if (e?.status === 404) setErrorMsg("User not found");
 			else setErrorMsg("Server error");
 			setState("error");
@@ -75,6 +77,7 @@ export function useTeamRegistration(eventId: string) {
 	const reset = () => {
 		setState("initial");
 		setErrorMsg("");
+		setTeamCode("");
 	};
 
 	return {

--- a/Client/src/lib/hooks/useUser.ts
+++ b/Client/src/lib/hooks/useUser.ts
@@ -4,10 +4,14 @@
    import { redirect }            from "next/navigation";
    
  
-   const API ="https://api.talkeys.xyz";          
+   const API = process.env.BACKEND_URL;
    
 
    const fetcher = async (endpoint: string) => {
+     if (!API) {
+       throw new Error("BACKEND_URL is not configured");
+     }
+
      const token = localStorage.getItem("accessToken") ?? "";
    
      const res = await fetch(`${API}${endpoint}`, {
@@ -37,4 +41,3 @@
        mutate,
      };
    }
-   

--- a/Client/src/lib/services/eventApi.ts
+++ b/Client/src/lib/services/eventApi.ts
@@ -2,13 +2,20 @@
 export type ApiError = { message: string };
 const BASE = process.env.BACKEND_URL;
 
+const apiUrl = (path: string) => {
+	if (!BASE) {
+		throw new Error("BACKEND_URL is not configured");
+	}
+	return `${BASE}${path}`;
+};
+
 const authHeaders = () => ({
 	"Content-Type": "application/json",
 	Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
 });
 
 export async function getPass(eventId: string) {
-	const res = await fetch(`${BASE}/getPass`, {
+	const res = await fetch(apiUrl("/getPass"), {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({ eventId }),
@@ -19,7 +26,7 @@ export async function getPass(eventId: string) {
 }
 
 export async function joinTeam(teamCode: string, phoneNumber: string) {
-	const res = await fetch(`${BASE}/joinTeam`, {
+	const res = await fetch(apiUrl("/joinTeam"), {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({ teamCode, phoneNumber }),
@@ -34,7 +41,7 @@ export async function createTeamApi(opts: {
 	teamName: string;
 	eventId: string;
 }) {
-	const res = await fetch(`${BASE}/createTeam`, {
+	const res = await fetch(apiUrl("/createTeam"), {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({
@@ -49,20 +56,20 @@ export async function createTeamApi(opts: {
 }
 
 export async function likeEvent(eventId: string) {
-	return fetch(`${BASE}/likeEvent/${eventId}`, {
+	return fetch(apiUrl(`/likeEvent/${eventId}`), {
 		method: "GET",
 		headers: authHeaders(),
 	});
 }
 export async function unlikeEvent(eventId: string) {
-	return fetch(`${BASE}/unlikeEvent/${eventId}`, {
+	return fetch(apiUrl(`/unlikeEvent/${eventId}`), {
 		method: "GET",
 		headers: authHeaders(),
 	});
 }
 
 export async function bookPass(teamCode: string, eventId: string) {
-	const res = await fetch(`${BASE}/bookPass`, {
+	const res = await fetch(apiUrl("/bookPass"), {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify({ teamCode, eventId }),
@@ -76,8 +83,9 @@ export async function bookTicket(opts: {
 	eventId: string;
 	passType: string;
 	friends: Array<{ name: string; email: string; phone: string }>;
+	teamCode?: string;
 }) {
-	const res = await fetch(`${BASE}/api/book-ticket`, {
+	const res = await fetch(apiUrl("/api/book-ticket"), {
 		method: "POST",
 		headers: authHeaders(),
 		body: JSON.stringify(opts),

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -54,9 +54,10 @@
             }
         },
         "node_modules/@mongodb-js/saslprep": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-            "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+            "version": "1.4.11",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+            "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
+            "license": "MIT",
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
             }
@@ -91,12 +92,14 @@
         "node_modules/@types/webidl-conversions": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+            "license": "MIT"
         },
         "node_modules/@types/whatwg-url": {
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
             "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/webidl-conversions": "*"
             }
@@ -151,17 +154,68 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-            "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+            "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+            "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
+                "follow-redirects": "^1.16.0",
+                "form-data": "^4.0.5",
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
             }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/axios/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -230,48 +284,64 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+            "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
+                "bytes": "~3.1.2",
                 "content-type": "~1.0.5",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.13.0",
-                "raw-body": "2.5.2",
+                "destroy": "~1.2.0",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "on-finished": "~2.4.1",
+                "qs": "~6.15.1",
+                "raw-body": "~2.5.3",
                 "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
+                "unpipe": "~1.0.0"
             },
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+        "node_modules/body-parser/node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
             "dependencies": {
-                "side-channel": "^1.0.6"
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
             },
             "engines": {
-                "node": ">=0.6"
+                "node": ">= 0.8"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -294,6 +364,7 @@
             "version": "6.10.4",
             "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
             "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.20.1"
             }
@@ -399,6 +470,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -519,6 +591,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -625,6 +698,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -651,39 +725,39 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+            "version": "4.22.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+            "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
             "license": "MIT",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.3",
-                "content-disposition": "0.5.4",
+                "body-parser": "~1.20.5",
+                "content-disposition": "~0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.7.1",
-                "cookie-signature": "1.0.6",
+                "cookie": "~0.7.1",
+                "cookie-signature": "~1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.3.1",
-                "fresh": "0.5.2",
-                "http-errors": "2.0.0",
+                "finalhandler": "~1.3.1",
+                "fresh": "~0.5.2",
+                "http-errors": "~2.0.0",
                 "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
-                "on-finished": "2.4.1",
+                "on-finished": "~2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.12",
+                "path-to-regexp": "~0.1.12",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.13.0",
+                "qs": "~6.15.1",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.19.0",
-                "serve-static": "1.16.2",
+                "send": "~0.19.0",
+                "serve-static": "~1.16.2",
                 "setprototypeof": "1.2.0",
-                "statuses": "2.0.1",
+                "statuses": "~2.0.1",
                 "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
@@ -723,39 +797,16 @@
             }
         },
         "node_modules/express-validator": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
-            "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+            "integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
             "license": "MIT",
             "dependencies": {
-                "lodash": "^4.17.21",
-                "validator": "~13.12.0"
+                "lodash": "^4.18.1",
+                "validator": "~13.15.23"
             },
             "engines": {
                 "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/express/node_modules/cookie": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-            "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.13.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-            "dependencies": {
-                "side-channel": "^1.0.6"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/extend": {
@@ -817,15 +868,16 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -836,9 +888,10 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-            "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -1054,6 +1107,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -1205,19 +1259,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/joi": {
             "version": "17.13.3",
             "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
@@ -1280,23 +1321,23 @@
             }
         },
         "node_modules/jsonwebtoken/node_modules/jwa": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-            "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+            "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
             "license": "MIT",
             "dependencies": {
-                "buffer-equal-constant-time": "1.0.1",
+                "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
                 "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/jsonwebtoken/node_modules/jws": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-            "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+            "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
             "license": "MIT",
             "dependencies": {
-                "jwa": "^1.4.1",
+                "jwa": "^1.4.2",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -1317,11 +1358,12 @@
             }
         },
         "node_modules/jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+            "license": "MIT",
             "dependencies": {
-                "jwa": "^2.0.0",
+                "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
             }
         },
@@ -1335,9 +1377,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "license": "MIT"
         },
         "node_modules/lodash.get": {
@@ -1427,7 +1469,8 @@
         "node_modules/memory-pager": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "license": "MIT"
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.3",
@@ -1481,9 +1524,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1493,44 +1536,25 @@
                 "node": "*"
             }
         },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/mongodb-connection-string-url": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
             "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@types/whatwg-url": "^11.0.2",
                 "whatwg-url": "^14.1.0 || ^13.0.0"
             }
         },
         "node_modules/mongoose": {
-            "version": "8.16.2",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.2.tgz",
-            "integrity": "sha512-52T4XPhDgJL4cqooBsOORzYBH3ddMwABMEF/LV7TgvD2DEKZlnYTc2HF9ch1U2lcKjhE4pQ+WuInfLFJbguGcQ==",
+            "version": "8.24.0",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
+            "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
+            "license": "MIT",
             "dependencies": {
                 "bson": "^6.10.4",
                 "kareem": "2.6.3",
-                "mongodb": "~6.17.0",
+                "mongodb": "~6.20.0",
                 "mpath": "0.9.0",
                 "mquery": "5.0.0",
                 "ms": "2.1.3",
@@ -1544,89 +1568,15 @@
                 "url": "https://opencollective.com/mongoose"
             }
         },
-        "node_modules/mongoose/node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/mongoose/node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mongoose/node_modules/gaxios": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-            "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.6.9"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mongoose/node_modules/gcp-metadata": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-            "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "gaxios": "^5.0.0",
-                "json-bigint": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/mongoose/node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/mongoose/node_modules/mongodb": {
-            "version": "6.17.0",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-            "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+            "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@mongodb-js/saslprep": "^1.1.9",
+                "@mongodb-js/saslprep": "^1.3.0",
                 "bson": "^6.10.4",
-                "mongodb-connection-string-url": "^3.0.0"
+                "mongodb-connection-string-url": "^3.0.2"
             },
             "engines": {
                 "node": ">=16.20.1"
@@ -1637,7 +1587,7 @@
                 "gcp-metadata": "^5.2.0",
                 "kerberos": "^2.0.1",
                 "mongodb-client-encryption": ">=6.0.0 <7",
-                "snappy": "^7.2.2",
+                "snappy": "^7.3.2",
                 "socks": "^2.7.1"
             },
             "peerDependenciesMeta": {
@@ -1670,63 +1620,17 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/mongoose/node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/mongoose/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/mongoose/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/mongoose/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/morgan": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-            "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+            "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
             "license": "MIT",
             "dependencies": {
                 "basic-auth": "~2.0.1",
                 "debug": "2.6.9",
                 "depd": "~2.0.0",
                 "on-finished": "~2.3.0",
-                "on-headers": "~1.0.2"
+                "on-headers": "~1.1.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -1795,20 +1699,22 @@
             "license": "MIT"
         },
         "node_modules/multer": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-            "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+            "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+            "license": "MIT",
             "dependencies": {
                 "append-field": "^1.0.0",
                 "busboy": "^1.6.0",
                 "concat-stream": "^2.0.0",
-                "mkdirp": "^0.5.6",
-                "object-assign": "^4.1.1",
-                "type-is": "^1.6.18",
-                "xtend": "^4.0.2"
+                "type-is": "^1.6.18"
             },
             "engines": {
                 "node": ">= 10.16.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/negotiator": {
@@ -1857,9 +1763,10 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-            "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+            "version": "7.0.13",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+            "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+            "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1961,9 +1868,9 @@
             }
         },
         "node_modules/on-headers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1979,15 +1886,15 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2011,9 +1918,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
@@ -2026,6 +1937,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -2042,9 +1954,10 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },
@@ -2065,16 +1978,45 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+            "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
             "license": "MIT",
             "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.4.24",
+                "unpipe": "~1.0.0"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/raw-body/node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/raw-body/node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2309,6 +2251,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
             "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "license": "MIT",
             "dependencies": {
                 "memory-pager": "^1.0.2"
             }
@@ -2387,6 +2330,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
             "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -2443,21 +2387,22 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
             ],
+            "license": "MIT",
             "bin": {
                 "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/validator": {
-            "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-            "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+            "version": "13.15.35",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+            "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
@@ -2484,6 +2429,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
             "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
             }
@@ -2492,6 +2438,7 @@
             "version": "14.2.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
             "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "license": "MIT",
             "dependencies": {
                 "tr46": "^5.1.0",
                 "webidl-conversions": "^7.0.0"
@@ -2501,9 +2448,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -2518,15 +2466,6 @@
                 "utf-8-validate": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4"
             }
         },
         "node_modules/zod": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -8,7 +8,8 @@
         "setup": "npm install && npm update",
         "start": "node src/server.js",
         "seed": "node src/seed.js",
-        "dev": "nodemon src/server.js"
+        "dev": "nodemon src/server.js",
+        "test": "node --test"
     },
     "keywords": [
         "express",

--- a/Server/src/controllers/event.controller.js
+++ b/Server/src/controllers/event.controller.js
@@ -355,7 +355,7 @@ const registerForInfluencer = asyncHandler(async (req, res) => {
 
 		const { name, instaId, phone, followersCount, attendance } = req.body;
 
-		const newRegistration = InfluencerRegistration.create({
+		const newRegistration = await InfluencerRegistration.create({
 			name,
 			instaId,
 			phone,

--- a/Server/src/controllers/passes.controller.js
+++ b/Server/src/controllers/passes.controller.js
@@ -1,6 +1,7 @@
 const asyncHandler = require("express-async-handler");
 const Event = require("../models/events.model.js");
 const Pass = require("../models/passes.model.js");
+const Team = require("../models/teams.model.js");
 const User = require("../models/users.model.js");
 const mongoose = require("mongoose");
 const crypto = require("crypto");
@@ -26,17 +27,41 @@ const getPhonePeConfig = () => {
   const configuredEnv = String(process.env.PHONEPE_ENV || "").toLowerCase();
 
   if (["production", "prod", "live"].includes(configuredEnv)) {
-    return CONFIG.production;
+    return {
+      AUTH_URL: process.env.PHONEPE_AUTH_URL || CONFIG.production.AUTH_URL,
+      BASE_URL: process.env.PHONEPE_BASE_URL || CONFIG.production.BASE_URL,
+      CHECKOUT_SCRIPT:
+        process.env.PHONEPE_CHECKOUT_SCRIPT ||
+        CONFIG.production.CHECKOUT_SCRIPT,
+    };
   }
 
   if (["sandbox", "staging", "test", "preprod", "uat", "development"].includes(configuredEnv)) {
-    return CONFIG.sandbox;
+    return {
+      AUTH_URL: process.env.PHONEPE_AUTH_URL || CONFIG.sandbox.AUTH_URL,
+      BASE_URL: process.env.PHONEPE_BASE_URL || CONFIG.sandbox.BASE_URL,
+      CHECKOUT_SCRIPT:
+        process.env.PHONEPE_CHECKOUT_SCRIPT || CONFIG.sandbox.CHECKOUT_SCRIPT,
+    };
   }
 
-  return String(process.env.PHONEPE_CLIENT_ID || "").startsWith("TEST-")
+  const defaultConfig = String(process.env.PHONEPE_CLIENT_ID || "").startsWith("TEST-")
     ? CONFIG.sandbox
     : CONFIG.production;
+
+  return {
+    AUTH_URL: process.env.PHONEPE_AUTH_URL || defaultConfig.AUTH_URL,
+    BASE_URL: process.env.PHONEPE_BASE_URL || defaultConfig.BASE_URL,
+    CHECKOUT_SCRIPT:
+      process.env.PHONEPE_CHECKOUT_SCRIPT || defaultConfig.CHECKOUT_SCRIPT,
+  };
 };
+
+const basicPassRequiredEventIds = () =>
+  String(process.env.BASIC_PASS_REQUIRED_EVENT_IDS || "")
+    .split(",")
+    .map((eventId) => eventId.trim())
+    .filter(Boolean);
 
 const normalizePhonePeStatus = (paymentStatus = {}) => {
   const data = paymentStatus.data || paymentStatus;
@@ -60,6 +85,47 @@ const sanitizeFriends = (friends = []) => {
     phone: friend?.phone ? String(friend.phone).trim().slice(0, 20) : undefined,
   }));
 };
+
+const getTeamBooking = async (event, userId, teamCode) => {
+  if (!event.isTeamEvent) {
+    return null;
+  }
+
+  if (!teamCode) {
+    throw Object.assign(new Error("Team code is required for this event"), {
+      statusCode: 400,
+    });
+  }
+
+  const team = await Team.findOne({
+    eventId: event._id,
+    teamCode: String(teamCode).trim().toUpperCase(),
+  });
+
+  if (!team) {
+    throw Object.assign(new Error("Team not found"), { statusCode: 404 });
+  }
+
+  const isMember = team.teamMembers.some(
+    (member) => member.userId.toString() === userId.toString(),
+  );
+  if (!isMember) {
+    throw Object.assign(new Error("User is not a member of this team"), {
+      statusCode: 403,
+    });
+  }
+
+  return team;
+};
+
+const teamMembersToFriends = (team, userId) =>
+  team.teamMembers
+    .filter((member) => member.userId.toString() !== userId.toString())
+    .map((member) => ({
+      name: member.name,
+      email: member.email,
+      phone: member.phoneNumber,
+    }));
 
 const buildQRStrings = (user, friends = []) => {
   const qrStrings = [
@@ -251,7 +317,7 @@ const bookTicket = async (req, res) => {
         error: "Event not found",
       });
     }
-    if (req.body.eventId == "6941834009f38cd886cb1aa0") {
+    if (basicPassRequiredEventIds().includes(req.body.eventId)) {
       const basicPass = await Pass.findOne({
         userId: req.user._id,
         paymentStatus: "completed",
@@ -265,7 +331,10 @@ const bookTicket = async (req, res) => {
       }
     }
 
-    const friends = sanitizeFriends(req.body.friends);
+    const team = await getTeamBooking(event, req.user._id, req.body.teamCode);
+    const friends = team
+      ? teamMembersToFriends(team, req.user._id)
+      : sanitizeFriends(req.body.friends);
     const totalTicketsNeeded = 1 + friends.length;
     const ticketPrice = Number(event.ticketPrice || 0);
     const totalAmount = ticketPrice * totalTicketsNeeded;
@@ -394,6 +463,13 @@ const bookTicket = async (req, res) => {
       },
     });
   } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json({
+        success: false,
+        error: error.message,
+      });
+    }
+
     if (pass?.seatsReserved && pass.paymentStatus !== "completed") {
       try {
         await releaseReservedSeats(pass);
@@ -1206,6 +1282,7 @@ module.exports = {
   admnDetails,
   _test: {
     buildQRStrings,
+    basicPassRequiredEventIds,
     getPhonePeConfig,
     normalizePhonePeStatus,
     sanitizeFriends,

--- a/Server/src/controllers/passes.controller.js
+++ b/Server/src/controllers/passes.controller.js
@@ -1,45 +1,139 @@
 const asyncHandler = require("express-async-handler");
-const express = require("express");
-const auth = require("../middleware/oauth.js");
 const Event = require("../models/events.model.js");
 const Pass = require("../models/passes.model.js");
 const User = require("../models/users.model.js");
 const mongoose = require("mongoose");
-const nodemailer = require("nodemailer");
 const crypto = require("crypto");
 const { v4: uuidv4 } = require("uuid");
 const axios = require("axios");
 const qs = require("qs");
-const { listeners } = require("../models/registration.model.js");
 
 const CONFIG = {
-  PRODUCTION: {
+  production: {
     AUTH_URL: "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
-    BASE_URL: "	https://api.phonepe.com/apis/pg",
+    BASE_URL: "https://api.phonepe.com/apis/pg",
     CHECKOUT_SCRIPT: "https://mercury.phonepe.com/web/bundle/checkout.js",
   },
-  STAGING: {
-    AUTH_URL: "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
-    BASE_URL: "	https://api.phonepe.com/apis/pg",
+  sandbox: {
+    AUTH_URL: "https://api-preprod.phonepe.com/apis/pg-sandbox/v1/oauth/token",
+    BASE_URL: "https://api-preprod.phonepe.com/apis/pg-sandbox",
+    CHECKOUT_SCRIPT: "https://mercury-uat.phonepe.com/web/bundle/checkout.js",
   },
-  CLIENT_VERSION: "1.0",
+  CLIENT_VERSION: "1",
 };
 
-// Environment configuration - use environment variables for security
-const ENVIRONMENT = process.env.PHONEPE_ENV;
-const CLIENT_ID = process.env.PHONEPE_CLIENT_ID;
-const CLIENT_SECRET = process.env.PHONEPE_CLIENT_SECRET;
+const getPhonePeConfig = () => {
+  const configuredEnv = String(process.env.PHONEPE_ENV || "").toLowerCase();
+
+  if (["production", "prod", "live"].includes(configuredEnv)) {
+    return CONFIG.production;
+  }
+
+  if (["sandbox", "staging", "test", "preprod", "uat", "development"].includes(configuredEnv)) {
+    return CONFIG.sandbox;
+  }
+
+  return String(process.env.PHONEPE_CLIENT_ID || "").startsWith("TEST-")
+    ? CONFIG.sandbox
+    : CONFIG.production;
+};
+
+const normalizePhonePeStatus = (paymentStatus = {}) => {
+  const data = paymentStatus.data || paymentStatus;
+  return {
+    state: paymentStatus.state || data.state,
+    orderId: paymentStatus.orderId || data.orderId,
+    amount: paymentStatus.amount || data.amount,
+    paymentDetails: paymentStatus.paymentDetails || data.paymentDetails || [],
+    reason: paymentStatus.reason || data.reason,
+  };
+};
+
+const sanitizeFriends = (friends = []) => {
+  if (!Array.isArray(friends)) {
+    return [];
+  }
+
+  return friends.slice(0, 9).map((friend) => ({
+    name: String(friend?.name || "Friend").trim().slice(0, 80) || "Friend",
+    email: friend?.email ? String(friend.email).trim().slice(0, 120) : undefined,
+    phone: friend?.phone ? String(friend.phone).trim().slice(0, 20) : undefined,
+  }));
+};
+
+const buildQRStrings = (user, friends = []) => {
+  const qrStrings = [
+    {
+      id: uuidv4(),
+      personType: "user",
+      personIndex: 0,
+      personName: user?.name || "Main User",
+      qrScanned: false,
+      scannedAt: null,
+    },
+  ];
+
+  friends.slice(0, 9).forEach((friend, index) => {
+    qrStrings.push({
+      id: uuidv4(),
+      personType: "friend",
+      personIndex: index + 1,
+      personName: friend.name || `Friend ${index + 1}`,
+      qrScanned: false,
+      scannedAt: null,
+    });
+  });
+
+  return qrStrings;
+};
+
+const reserveSeats = async (eventId, ticketCount) => {
+  return Event.findOneAndUpdate(
+    {
+      _id: eventId,
+      $expr: {
+        $lte: [
+          { $add: [{ $ifNull: ["$registrationCount", 0] }, ticketCount] },
+          "$totalSeats",
+        ],
+      },
+    },
+    { $inc: { registrationCount: ticketCount } },
+    { new: true },
+  );
+};
+
+const releaseReservedSeats = async (pass) => {
+  if (!pass?.seatsReserved) {
+    return;
+  }
+
+  const ticketCount = pass.ticketCount || 1 + (pass.friends?.length || 0);
+  await Event.findByIdAndUpdate(pass.eventId, {
+    $inc: { registrationCount: -ticketCount },
+  });
+  pass.seatsReserved = false;
+};
+
+const findQRString = (pass, qrId) => {
+  return pass?.qrStrings?.find(
+    (qr) => qr.id === qrId || qr._id?.toString() === qrId,
+  );
+};
 
 const getPhonePeAccessToken = async () => {
   try {
-    console.log("[PhonePe] Requesting access token...");
+    const config = getPhonePeConfig();
+    const clientVersion =
+      process.env.PHONEPE_CLIENT_VERSION || CONFIG.CLIENT_VERSION;
+
     const response = await axios.post(
-      "https://api.phonepe.com/apis/identity-manager/v1/oauth/token",
+      config.AUTH_URL,
       qs.stringify({
         client_id: process.env.PHONEPE_CLIENT_ID,
         client_secret: process.env.PHONEPE_CLIENT_SECRET,
         grant_type: "client_credentials",
-        client_version: "1",
+        client_version: clientVersion,
       }),
       {
         headers: {
@@ -48,7 +142,12 @@ const getPhonePeAccessToken = async () => {
       },
     );
 
-    return response.data.access_token;
+    const accessToken = response.data?.access_token || response.data?.data?.access_token;
+    if (!accessToken) {
+      throw new Error("PhonePe auth response did not include an access token");
+    }
+
+    return accessToken;
   } catch (error) {
     console.error(
       "[PhonePe] Auth Error:",
@@ -63,7 +162,11 @@ const getPhonePeAccessToken = async () => {
 // Create Payment Order
 const createPhonePeOrder = async (orderData) => {
   try {
-    console.log("Creating PhonePe order with data:", orderData);
+    const config = getPhonePeConfig();
+    console.log("Creating PhonePe order:", {
+      merchantOrderId: orderData.merchantOrderId,
+      amount: orderData.amount,
+    });
     const accessToken = await getPhonePeAccessToken();
 
     const payload = {
@@ -86,7 +189,7 @@ const createPhonePeOrder = async (orderData) => {
     };
 
     const response = await axios.post(
-      `${CONFIG.PRODUCTION.BASE_URL}/checkout/v2/pay`,
+      `${config.BASE_URL}/checkout/v2/pay`,
       payload,
       {
         headers: {
@@ -97,7 +200,13 @@ const createPhonePeOrder = async (orderData) => {
       },
     );
 
-    return response.data;
+    const paymentOrder = response.data;
+    const paymentUrl = paymentOrder?.data?.redirectUrl || paymentOrder?.redirectUrl;
+    if (!paymentUrl) {
+      throw new Error("PhonePe order response did not include a payment URL");
+    }
+
+    return paymentOrder;
   } catch (error) {
     console.error("PhonePe order creation error:", {
       status: error.response?.status,
@@ -111,15 +220,19 @@ const createPhonePeOrder = async (orderData) => {
 };
 
 const bookTicket = async (req, res) => {
+  let pass;
   try {
-    console.log("Booking ticket request:", req.body);
-
-    // Validation
-    console.log("User:", req.user);
     if (!req.user?._id || !req.body.eventId) {
       return res.status(400).json({
         success: false,
         error: "User ID and Event ID are required",
+      });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(req.body.eventId)) {
+      return res.status(400).json({
+        success: false,
+        error: "Invalid Event ID",
       });
     }
 
@@ -152,13 +265,15 @@ const bookTicket = async (req, res) => {
       }
     }
 
-    const friends = req.body.friends || [];
+    const friends = sanitizeFriends(req.body.friends);
     const totalTicketsNeeded = 1 + friends.length;
-    const totalAmount = event.ticketPrice * totalTicketsNeeded;
-    const amountInPaisa = totalAmount * 100;
+    const ticketPrice = Number(event.ticketPrice || 0);
+    const totalAmount = ticketPrice * totalTicketsNeeded;
+    const amountInPaisa = Math.round(totalAmount * 100);
+    const isPaidBooking = Boolean(event.isPaid && amountInPaisa > 0);
 
-    // Validation checks
-    if (event.remainingSeats < totalTicketsNeeded) {
+    const reservedEvent = await reserveSeats(event._id, totalTicketsNeeded);
+    if (!reservedEvent) {
       return res.status(400).json({
         success: false,
         error: "Insufficient tickets available",
@@ -168,69 +283,92 @@ const bookTicket = async (req, res) => {
     // Generate unique merchant order ID with timestamp
     const merchantOrderId = `TKT_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-    console.log("Generated merchantOrderId:", merchantOrderId);
-
-    // Create temporary pass
-    const pass = new Pass({
+    pass = new Pass({
       userId: req.user?._id,
       eventId: req.body.eventId,
       passType: req.body.passType || "General",
-      status: "pending",
-      paymentStatus: "pending",
+      status: isPaidBooking ? "pending" : "active",
+      passStatus: isPaidBooking ? "inactive" : "active",
+      paymentStatus: isPaidBooking ? "pending" : "completed",
       merchantOrderId,
       amount: totalAmount,
+      ticketCount: totalTicketsNeeded,
+      seatsReserved: true,
       friends,
       createdAt: new Date(),
       expiresAt: new Date(Date.now() + 20 * 60 * 1000),
     });
-    console.log("Creating pass:", pass);
-    await pass.save();
-    console.log("Pass created with ID:", pass._id);
 
-    // Create PhonePe payment order
+    if (!isPaidBooking) {
+      pass.confirmedAt = new Date();
+      pass.paymentDetails = {
+        amount: 0,
+        completedAt: new Date(),
+        source: "free_registration",
+        merchantOrderId,
+      };
+      pass.qrStrings = buildQRStrings(user, friends);
+      await pass.save();
+
+      return res.status(200).json({
+        success: true,
+        message: "Free pass created successfully",
+        data: {
+          passId: pass._id,
+          passUUID: pass.passUUID,
+          merchantOrderId,
+          amount: totalAmount,
+          amountInPaisa,
+          totalTickets: totalTicketsNeeded,
+          paymentRequired: false,
+          paymentUrl: null,
+          event: {
+            id: event._id,
+            title: event.name,
+            date: event.startDate,
+            venue: event.location,
+          },
+          qrStrings: pass.qrStrings,
+          friends,
+        },
+      });
+    }
+
+    await pass.save();
+
     const orderData = {
       merchantOrderId,
       amount: amountInPaisa,
-      userId: req.body.userId,
+      userId: req.user._id.toString(),
       eventId: req.body.eventId,
-      eventName: event.title,
+      eventName: event.name,
       passType: req.body.passType || "General",
       friends,
-      mobileNumber: user.phone,
+      mobileNumber: user.phoneNumber,
     };
 
-    const paymentOrder = await createPhonePeOrder(orderData);
+    let paymentOrder;
+    try {
+      paymentOrder = await createPhonePeOrder(orderData);
+    } catch (error) {
+      pass.status = "payment_failed";
+      pass.passStatus = "inactive";
+      pass.paymentStatus = "failed";
+      pass.paymentDetails = {
+        amount: amountInPaisa,
+        failedAt: new Date(),
+        source: "order_creation",
+        reason: error.message,
+        merchantOrderId,
+      };
+      await releaseReservedSeats(pass);
+      await pass.save();
+      throw error;
+    }
 
-    // Update pass with payment details
     pass.phonePeOrderId = paymentOrder.data?.orderId || paymentOrder.orderId;
     pass.paymentUrl =
       paymentOrder.data?.redirectUrl || paymentOrder.redirectUrl;
-    console.log("saving pass");
-    await pass.save();
-
-    console.log(
-      "Redirect URL:",
-      `${process.env.BASE_URL}/api/payment/callback/${orderData.merchantOrderId}`,
-    );
-    console.log("Webhook URL:", `${process.env.BASE_URL}/api/payment/webhook`);
-    console.log("Payment order created successfully");
-
-    // Generate QR strings for the user and friends
-
-    const qrStrings = [];
-    qrStrings.push({
-      id: uuidv4(),
-      personName: user?.name || "You",
-    });
-    if (friends.length > 0) {
-      for (const friend of friends) {
-        qrStrings.push({
-          personName: friend.name || "Friend",
-        });
-      }
-    }
-    pass.qrStrings = qrStrings;
-    console.log("Saving QR strings to pass");
     await pass.save();
 
     return res.status(200).json({
@@ -247,15 +385,25 @@ const bookTicket = async (req, res) => {
         expiresAt: pass.expiresAt,
         event: {
           id: event._id,
-          title: event.title,
-          date: event.date,
-          venue: event.venue,
+          title: event.name,
+          date: event.startDate,
+          venue: event.location,
         },
-        qrStrings: qrStrings,
-        friends: friends,
+        qrStrings: [],
+        friends,
       },
     });
   } catch (error) {
+    if (pass?.seatsReserved && pass.paymentStatus !== "completed") {
+      try {
+        await releaseReservedSeats(pass);
+        if (!pass.isNew) {
+          await pass.save();
+        }
+      } catch (releaseError) {
+        console.error("Seat reservation release failed:", releaseError);
+      }
+    }
     console.error("Ticket booking error:", error);
     return res.status(500).json({
       success: false,
@@ -269,11 +417,10 @@ const bookTicket = async (req, res) => {
 // Enhanced Payment Status Check with Integrated Processing
 const checkPaymentStatus = async (merchantOrderId, shouldProcess = false) => {
   try {
+    const config = getPhonePeConfig();
     const accessToken = await getPhonePeAccessToken();
-    console.log("[STATUS] Access token acquired");
 
-    const url = `${CONFIG.PRODUCTION.BASE_URL}/checkout/v2/order/${merchantOrderId}/status`;
-    console.log("[STATUS] Checking status at:", url);
+    const url = `${config.BASE_URL}/checkout/v2/order/${merchantOrderId}/status`;
 
     const response = await axios.get(url, {
       headers: {
@@ -284,13 +431,11 @@ const checkPaymentStatus = async (merchantOrderId, shouldProcess = false) => {
       timeout: 10000,
     });
 
-    console.log("[STATUS] Response from PhonePe:", response.data);
-
     const paymentData = response.data;
 
     // If shouldProcess is true, automatically process the payment based on status
     if (shouldProcess && paymentData) {
-      const paymentState = paymentData.state || paymentData.data?.state;
+      const paymentState = normalizePhonePeStatus(paymentData).state;
 
       if (paymentState === "COMPLETED") {
         await processPaymentConfirmation(
@@ -327,39 +472,64 @@ const processPaymentConfirmation = async (
   source = "callback",
 ) => {
   try {
-    console.log(
-      `[${source}] Processing payment confirmation for:`,
-      merchantOrderId,
-    );
-
-    // Find pass by merchantOrderId instead of using metadata
     const pass = await Pass.findOne({ merchantOrderId });
 
     if (!pass) {
       throw new Error(`Pass not found for merchantOrderId: ${merchantOrderId}`);
     }
 
-    // Check if already processed
+    const user = await User.findById(pass.userId).select("name");
+
     if (pass.paymentStatus === "completed") {
-      console.log(`[${source}] Payment already processed for pass:`, pass._id);
+      let repaired = false;
+      if (!pass.passUUID) {
+        pass.passUUID = uuidv4();
+        repaired = true;
+      }
+      if (!pass.qrStrings?.length) {
+        pass.qrStrings = buildQRStrings(user, pass.friends);
+        repaired = true;
+      }
+      if (pass.status !== "active" || pass.passStatus !== "active") {
+        pass.status = "active";
+        pass.passStatus = "active";
+        repaired = true;
+      }
+      if (repaired) {
+        await pass.save();
+      }
+
       return {
         passId: pass._id,
-        passUUID: pass.passUUID || pass._id,
+        passUUID: pass.passUUID,
         success: true,
         message: "Payment already confirmed",
         alreadyProcessed: true,
       };
     }
 
-    // Update pass status
+    if (!pass.seatsReserved) {
+      const reservedEvent = await reserveSeats(
+        pass.eventId,
+        pass.ticketCount || 1 + (pass.friends?.length || 0),
+      );
+      if (!reservedEvent) {
+        throw new Error("Payment completed but no seats are available");
+      }
+      pass.seatsReserved = true;
+    }
+
+    const normalizedPayment = normalizePhonePeStatus(paymentStatus);
+
     pass.status = "active";
+    pass.passStatus = "active";
     pass.paymentStatus = "completed";
     pass.confirmedAt = new Date();
     pass.paymentDetails = {
-      orderId: paymentStatus.orderId,
-      transactionId: paymentStatus.paymentDetails?.[0]?.transactionId,
-      amount: paymentStatus.amount,
-      paymentMode: paymentStatus.paymentDetails?.[0]?.paymentMode,
+      orderId: normalizedPayment.orderId,
+      transactionId: normalizedPayment.paymentDetails?.[0]?.transactionId,
+      amount: normalizedPayment.amount,
+      paymentMode: normalizedPayment.paymentDetails?.[0]?.paymentMode,
       completedAt: new Date(),
       source: source,
       merchantOrderId: merchantOrderId,
@@ -369,6 +539,9 @@ const processPaymentConfirmation = async (
     if (!pass.passUUID) {
       pass.passUUID = uuidv4();
     }
+    if (!pass.qrStrings?.length) {
+      pass.qrStrings = buildQRStrings(user, pass.friends);
+    }
 
     await pass.save();
 
@@ -376,11 +549,6 @@ const processPaymentConfirmation = async (
     await User.findByIdAndUpdate(pass.userId, {
       $inc: { activePasses: 1 },
     });
-
-    console.log(
-      `[${source}] Payment confirmed successfully for pass:`,
-      pass._id,
-    );
 
     return {
       passId: pass._id,
@@ -401,25 +569,24 @@ const processPaymentFailure = async (
   source = "callback",
 ) => {
   try {
-    console.log(`[${source}] Processing payment failure for:`, merchantOrderId);
-
     const pass = await Pass.findOne({
       merchantOrderId: merchantOrderId,
-      status: "pending",
     });
 
-    if (pass) {
-      // Update pass status to failed
+    if (pass && pass.paymentStatus !== "completed") {
+      const normalizedPayment = normalizePhonePeStatus(paymentStatus);
       pass.status = "payment_failed";
+      pass.passStatus = "inactive";
       pass.paymentStatus = "failed";
       pass.paymentDetails = {
-        orderId: paymentStatus.orderId,
-        amount: paymentStatus.amount,
+        orderId: normalizedPayment.orderId,
+        amount: normalizedPayment.amount,
         failedAt: new Date(),
         source: source,
-        reason: paymentStatus.reason || "Payment failed",
+        reason: normalizedPayment.reason || "Payment failed",
         merchantOrderId: merchantOrderId,
       };
+      await releaseReservedSeats(pass);
 
       await pass.save();
     }
@@ -443,8 +610,14 @@ const validateWebhookSignature = (username, password, receivedSignature) => {
       .createHash("sha256")
       .update(credentials)
       .digest("hex");
+    if (!receivedSignature || receivedSignature.length !== expectedSignature.length) {
+      return false;
+    }
 
-    return expectedSignature === receivedSignature;
+    return crypto.timingSafeEqual(
+      Buffer.from(expectedSignature),
+      Buffer.from(receivedSignature),
+    );
   } catch (error) {
     console.error("Error validating webhook signature:", error);
     return false;
@@ -468,34 +641,22 @@ const htmlRedirect = (url) => `
 // Enhanced Payment Callback Handler
 const handlePaymentCallback = async (req, res) => {
   try {
-    console.log("Payment callback initiated");
     const { merchantOrderId } = req.params;
-    console.log("[CALLBACK] Received callback for:", merchantOrderId);
 
-    // Step 1: Fetch status from PhonePe with processing enabled
     const paymentStatus = await checkPaymentStatus(merchantOrderId, true);
-    console.log("[CALLBACK] PhonePe status processed:", paymentStatus);
 
-    // Validate response
     if (!paymentStatus || typeof paymentStatus !== "object") {
       throw new Error("Invalid payment status response from PhonePe");
     }
 
-    const paymentState = paymentStatus.state || paymentStatus.data?.state;
+    const paymentState = normalizePhonePeStatus(paymentStatus).state;
     if (!paymentState) {
-      console.log(
-        '[CALLBACK] Payment status missing "state" field:',
-        paymentStatus,
-      );
       throw new Error("Missing 'state' in PhonePe response");
     }
 
-    // Find pass to get details
     const pass = await Pass.findOne({ merchantOrderId: merchantOrderId });
 
-    // Step 2: Route based on payment state
     if (paymentState === "COMPLETED") {
-      console.log("[CALLBACK] Payment completed. Redirecting to success");
       return res.redirect(
         302,
         `${process.env.FRONTEND_URL}/ticket/success?passId=${pass?._id}&uuid=${pass?.passUUID}`,
@@ -503,15 +664,12 @@ const handlePaymentCallback = async (req, res) => {
     }
 
     if (paymentState === "FAILED") {
-      console.log("[CALLBACK] Payment failed. Redirecting to failure");
       return res.redirect(
         302,
         `${process.env.FRONTEND_URL}/ticket/failure?passId=${pass ? pass._id : ""}&orderId=${merchantOrderId}`,
       );
     }
 
-    // PENDING or unknown status
-    console.log("[CALLBACK] Payment pending. Redirecting to pending page.");
     return res.redirect(
       302,
       `${process.env.FRONTEND_URL}/ticket/pending?orderId=${merchantOrderId}`,
@@ -533,12 +691,10 @@ const handlePaymentCallback = async (req, res) => {
 const handleManualStatusCheck = async (req, res) => {
   try {
     const { merchantOrderId } = req.params;
-    console.log("[MANUAL_CHECK] Checking status for:", merchantOrderId);
 
-    // Check status with processing enabled
     const paymentStatus = await checkPaymentStatus(merchantOrderId, true);
 
-    const paymentState = paymentStatus.state || paymentStatus.data?.state;
+    const paymentState = normalizePhonePeStatus(paymentStatus).state;
 
     return res.status(200).json({
       success: true,
@@ -560,7 +716,9 @@ const handleManualStatusCheck = async (req, res) => {
 // Enhanced Webhook Handler
 const handlePaymentWebhook = async (req, res) => {
   try {
-    console.log("Webhook received:", req.body);
+    const webhookBody = Buffer.isBuffer(req.body)
+      ? JSON.parse(req.body.toString("utf8"))
+      : req.body;
 
     // Validate webhook signature if configured
     if (
@@ -585,7 +743,10 @@ const handlePaymentWebhook = async (req, res) => {
       }
     }
 
-    const { event, payload } = req.body;
+    const { event, payload } = webhookBody || {};
+    if (!event || !payload?.merchantOrderId) {
+      return res.status(400).json({ error: "Invalid webhook payload" });
+    }
 
     if (event === "checkout.order.completed") {
       await processPaymentConfirmation(
@@ -711,33 +872,24 @@ const getPassForQR = async (req, res) => {
 const getTicketStatus = async (req, res) => {
   try {
     const { passId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(passId)) {
+      return res.status(400).json({ error: "Invalid Pass ID" });
+    }
 
-    const pass = await Pass.findById(passId)
-      .populate("userId", "name email phone")
-      .populate("eventId", "title date venue location");
+    let pass = await Pass.findById(passId)
+      .populate("userId", "name email phoneNumber")
+      .populate("eventId", "name startDate location");
 
     if (!pass) {
       return res.status(404).json({ error: "Pass not found" });
     }
 
-    // If payment is still pending, check status from PhonePe
-    if (pass.status === "pending" && pass.merchantOrderId) {
+    if (pass.paymentStatus === "pending" && pass.merchantOrderId) {
       try {
-        const paymentStatus = await checkPaymentStatus(pass.merchantOrderId);
-
-        if (paymentStatus.state === "COMPLETED") {
-          pass.status = "active";
-          pass.paymentStatus = "completed";
-          pass.confirmedAt = new Date();
-          if (!pass.passUUID) {
-            pass.passUUID = uuidv4();
-          }
-          await pass.save();
-        } else if (paymentStatus.state === "FAILED") {
-          pass.status = "payment_failed";
-          pass.paymentStatus = "failed";
-          await pass.save();
-        }
+        await checkPaymentStatus(pass.merchantOrderId, true);
+        pass = await Pass.findById(passId)
+          .populate("userId", "name email phoneNumber")
+          .populate("eventId", "name startDate location");
       } catch (error) {
         console.error("Error checking payment status:", error);
       }
@@ -748,7 +900,7 @@ const getTicketStatus = async (req, res) => {
       data: {
         pass: pass,
         qrCode:
-          pass.status === "active"
+          pass.paymentStatus === "completed" && pass.passUUID
             ? generateQRCode(pass.passUUID || pass._id)
             : null,
       },
@@ -768,12 +920,15 @@ const generateQRCode = (passIdentifier) => {
 const cleanupExpiredPasses = async () => {
   try {
     const expiredPasses = await Pass.find({
-      status: "pending",
+      paymentStatus: "pending",
       expiresAt: { $lt: new Date() },
     });
 
     for (const pass of expiredPasses) {
       pass.status = "expired";
+      pass.passStatus = "expired";
+      pass.paymentStatus = "failed";
+      await releaseReservedSeats(pass);
       await pass.save();
     }
 
@@ -789,11 +944,14 @@ const getPassByUUID = async (req, res) => {
       return res.status(400).json({ error: "Pass UUID is required" });
     }
 
-    const pass = await Pass.findOne({ passUUID: passUUID })
+    const pass = await Pass.findOne({
+      passUUID: passUUID,
+      paymentStatus: "completed",
+    })
       .populate("userId", "name")
       .populate("eventId", "name startDate")
       .select(
-        "eventId userId paymentStatus createdAt amount friends passUUID passType",
+        "eventId userId paymentStatus status createdAt amount friends passUUID passType ticketCount",
       );
 
     if (!pass) {
@@ -808,8 +966,8 @@ const getPassByUUID = async (req, res) => {
       passEventDate: pass.eventId?.startDate || "Unknown Date",
       passPaymentStatus: pass.paymentStatus || "ERROR",
       passCreatedAt: pass.createdAt || "NO",
-      passStatus: pass.paymentStatus || "ERROR",
-      passEnteries: pass.friends.length + 1, // Including the main userP
+      passStatus: pass.status || pass.paymentStatus || "ERROR",
+      passEnteries: pass.ticketCount || pass.friends.length + 1,
       eventId: pass.eventId?._id || "Unknown Event ID",
       // Additional fields that might be useful
     };
@@ -826,6 +984,10 @@ const getPassByUUID = async (req, res) => {
 
 const getPassByUserAndEvent = async (req, res) => {
   try {
+    if (!mongoose.Types.ObjectId.isValid(req.body.eventId)) {
+      return res.status(400).json({ error: "Invalid Event ID" });
+    }
+
     const passes = await Pass.find({
       userId: req.user._id,
       eventId: req.body.eventId,
@@ -849,8 +1011,6 @@ const getPassByUserAndEvent = async (req, res) => {
       };
     });
 
-    console.log("Passes found:", passesData.length);
-
     return res.status(200).json({
       passes: passesData,
       count: passesData.length,
@@ -863,40 +1023,34 @@ const getPassByUserAndEvent = async (req, res) => {
 };
 const getPassByQrStringsAndPassUUID = async (req, res) => {
   try {
+    if (!req.body.passUUID || !req.body.qrId) {
+      return res.status(400).json({ error: "Pass UUID and QR ID are required" });
+    }
+
     const pass = await Pass.findOne({
       passUUID: req.body.passUUID,
-    }).populate("eventId");
-
-    console.log(req.body.qrId);
-    console.log(pass);
+      paymentStatus: "completed",
+    })
+      .populate("eventId", "name")
+      .populate("userId", "name");
 
     if (!pass) {
       return res.status(404).json({ error: "Valid pass not found" });
     }
 
-    let person = null;
-
-    // Check if qrStrings exists and is an array
-    if (pass.qrStrings && Array.isArray(pass.qrStrings)) {
-      // Use for...of loop to iterate over the actual objects
-      for (const qr of pass.qrStrings) {
-        if (qr._id && qr._id.toString() === req.body.qrId) {
-          console.log("QR found", qr);
-          person = qr;
-          break;
-        }
-      }
+    const person = findQRString(pass, req.body.qrId);
+    if (!person) {
+      return res.status(404).json({ error: "QR code not found" });
     }
-
-    console.log("Found person:", person);
 
     return res.status(200).json({
       success: true,
       data: {
-        buyer: pass.userId.name,
-        event: pass.eventId.name,
+        buyer: pass.userId?.name || "Unknown buyer",
+        event: pass.eventId?.name || "Unknown event",
         person,
         amount: pass.amount,
+        paymentStatus: pass.paymentStatus,
       },
     });
   } catch (error) {
@@ -906,35 +1060,48 @@ const getPassByQrStringsAndPassUUID = async (req, res) => {
 };
 const Accept = async (req, res) => {
   try {
-    let passUUID = req.body.uuid;
+    const passUUID = req.body.uuid;
     if (!passUUID) {
       return res.status(400).json({ error: "Pass UUID is required" });
     }
-    let qrId = req.body.qrId;
+    const qrId = req.body.qrId;
     if (!qrId) {
       return res.status(400).json({ error: "QR ID is required" });
     }
 
-    // Find pass by passUUID field, not by _id
     const pass = await Pass.findOne({ passUUID });
     if (!pass) {
       return res.status(404).json({ error: "Pass not found" });
     }
 
-    // Find the QR string by _id
-    const qrString = pass.qrStrings.find((qr) => qr._id.toString() === qrId);
+    if (pass.paymentStatus !== "completed") {
+      return res.status(400).json({ error: "Pass is not active" });
+    }
+    if (pass.status !== "active" || pass.passStatus !== "active") {
+      pass.status = "active";
+      pass.passStatus = "active";
+    }
+
+    const qrString = findQRString(pass, qrId);
     if (!qrString) {
       return res.status(404).json({ error: "QR code not found" });
     }
 
-    if (qrString.isScanned) {
+    if (qrString.qrScanned) {
       return res.status(400).json({ error: "QR code already scanned" });
     }
 
     qrString.scannedAt = new Date();
     qrString.qrScanned = true;
+    if (pass.qrStrings.every((qr) => qr.qrScanned || qr._id.toString() === qrString._id.toString())) {
+      pass.isScanned = true;
+      pass.timeScanned = qrString.scannedAt;
+    }
     await pass.save();
-    return res.status(200).json({ message: "Pass scanned successfully" });
+    return res.status(200).json({
+      message: "Pass scanned successfully",
+      scannedAt: qrString.scannedAt,
+    });
   } catch (error) {
     console.error("Accept pass error:", error);
     return res.status(500).json({ error: "Internal server error" });
@@ -975,11 +1142,6 @@ const Accept = async (req, res) => {
 
 const canScan = async (req, res) => {
   let user = req.user;
-  let eventId = req.body.eventId;
-  const event = await Event.findById(eventId);
-  if (user.role !== "admin" && user.role !== "event_manager") {
-    return res.status(403).json({ error: "Forbidden: Invalid role" });
-  }
   try {
     if (user.role !== "admin") {
       return res.status(403).json({ error: "Forbidden: Invalid role" });
@@ -994,22 +1156,22 @@ const canScan = async (req, res) => {
 
 const admnDetails = async (req, res) => {
   let user = req.user;
-  let eventId = req.body.eventId;
-  const event = await Event.findById(eventId);
-  if (user.role !== "admin" && user.role !== "event_manager") {
-    return res.status(403).json({ error: "Forbidden: Invalid role" });
-  }
   try {
     if (user.role !== "admin") {
       return res.status(403).json({ error: "Forbidden: Invalid role" });
     }
-    // fetch all passes with completed
-    const passes = await Pass.find({ paymentStatus: "completed" });
-    // calculate total number of passes
-    const totalDocuments = passes.length - 3;
-    // add all the amount - 9* length of documents
+    const query = { paymentStatus: "completed" };
+    if (req.query.eventId && mongoose.Types.ObjectId.isValid(req.query.eventId)) {
+      query.eventId = req.query.eventId;
+    }
+
+    const passes = await Pass.find(query);
+    const totalOrders = passes.length;
+    const totalTickets = passes.reduce(
+      (acc, pass) => acc + (pass.ticketCount || 1 + (pass.friends?.length || 0)),
+      0,
+    );
     const totalAmount = passes.reduce((acc, pass) => acc + pass.amount, 0);
-    const totalAmountAfterAdjustment = totalAmount - 5 - 9 * totalDocuments;
 
     const y2kPasses = await Pass.find({
       paymentStatus: "completed",
@@ -1019,8 +1181,9 @@ const admnDetails = async (req, res) => {
 
     return res.status(200).json({
       message: "Details fetched successfully",
-      passes: totalDocuments,
-      amount: totalAmountAfterAdjustment,
+      orders: totalOrders,
+      passes: totalTickets,
+      amount: totalAmount,
       y2kPasses: y2kPassesCount,
     });
   } catch (error) {
@@ -1041,4 +1204,11 @@ module.exports = {
   cleanupExpiredPasses,
   getPassByUUID,
   admnDetails,
+  _test: {
+    buildQRStrings,
+    getPhonePeConfig,
+    normalizePhonePeStatus,
+    sanitizeFriends,
+    validateWebhookSignature,
+  },
 };

--- a/Server/src/controllers/team.controller.js
+++ b/Server/src/controllers/team.controller.js
@@ -1,0 +1,149 @@
+const crypto = require("crypto");
+const mongoose = require("mongoose");
+const Event = require("../models/events.model");
+const Team = require("../models/teams.model");
+
+const normalizePhone = (phoneNumber = "") =>
+  String(phoneNumber).replace(/[^\d+]/g, "").trim();
+
+const toTeamDTO = (team) => ({
+  _id: team._id,
+  eventId: team.eventId,
+  teamName: team.teamName,
+  teamCode: team.teamCode,
+  teamLeader: team.teamLeader,
+  teamMembers: team.teamMembers,
+  maxMembers: team.maxMembers,
+});
+
+const createTeamCode = () =>
+  crypto.randomBytes(4).toString("hex").toUpperCase();
+
+const makeMember = (user, phoneNumber) => ({
+  userId: user._id,
+  name: user.name,
+  email: user.email,
+  phoneNumber,
+});
+
+const getTeamCapacity = (event) => Math.max(Number(event.slots || 1), 1);
+
+const createTeam = async (req, res) => {
+  try {
+    const { eventId, teamName } = req.body;
+    const phoneNumber = normalizePhone(req.body.newPhoneNumber || req.body.phoneNumber);
+
+    if (!eventId || !mongoose.Types.ObjectId.isValid(eventId)) {
+      return res.status(400).json({ error: "Valid Event ID is required" });
+    }
+
+    if (!teamName || String(teamName).trim().length < 2) {
+      return res.status(400).json({ error: "Team name is required" });
+    }
+
+    if (!phoneNumber || phoneNumber.length < 10) {
+      return res.status(400).json({ error: "Valid phone number is required" });
+    }
+
+    const event = await Event.findById(eventId);
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" });
+    }
+
+    if (!event.isTeamEvent) {
+      return res.status(400).json({ error: "This event does not support team registration" });
+    }
+
+    const existingMembership = await Team.findOne({
+      eventId,
+      "teamMembers.userId": req.user._id,
+    });
+    if (existingMembership) {
+      return res.status(400).json({ error: "User is already in a team for this event" });
+    }
+
+    let teamCode;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const candidate = createTeamCode();
+      const exists = await Team.exists({ teamCode: candidate });
+      if (!exists) {
+        teamCode = candidate;
+        break;
+      }
+    }
+
+    if (!teamCode) {
+      return res.status(500).json({ error: "Could not generate team code" });
+    }
+
+    const team = await Team.create({
+      eventId,
+      teamName: String(teamName).trim(),
+      teamCode,
+      teamLeader: req.user._id,
+      teamMembers: [makeMember(req.user, phoneNumber)],
+      maxMembers: getTeamCapacity(event),
+    });
+
+    return res.status(201).json({ team: toTeamDTO(team), teamCode: team.teamCode });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(400).json({ error: "Team already exists for this event" });
+    }
+
+    console.error("Create team error:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+const joinTeam = async (req, res) => {
+  try {
+    const { teamCode } = req.body;
+    const phoneNumber = normalizePhone(req.body.phoneNumber);
+
+    if (!teamCode) {
+      return res.status(400).json({ error: "Team code is required" });
+    }
+
+    if (!phoneNumber || phoneNumber.length < 10) {
+      return res.status(400).json({ error: "Valid phone number is required" });
+    }
+
+    const team = await Team.findOne({ teamCode: String(teamCode).trim().toUpperCase() });
+    if (!team) {
+      return res.status(404).json({ error: "Team not found" });
+    }
+
+    const alreadyInTeam = team.teamMembers.some(
+      (member) => member.userId.toString() === req.user._id.toString(),
+    );
+    if (alreadyInTeam) {
+      return res.status(200).json({ teamName: team.teamName, team: toTeamDTO(team) });
+    }
+
+    const existingMembership = await Team.findOne({
+      eventId: team.eventId,
+      "teamMembers.userId": req.user._id,
+    });
+    if (existingMembership) {
+      return res.status(400).json({ error: "User is already in a team for this event" });
+    }
+
+    if (team.teamMembers.length >= team.maxMembers) {
+      return res.status(400).json({ error: "Team is full" });
+    }
+
+    team.teamMembers.push(makeMember(req.user, phoneNumber));
+    await team.save();
+
+    return res.status(200).json({ teamName: team.teamName, team: toTeamDTO(team) });
+  } catch (error) {
+    console.error("Join team error:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+module.exports = {
+  createTeam,
+  joinTeam,
+};

--- a/Server/src/models/passes.model.js
+++ b/Server/src/models/passes.model.js
@@ -1,4 +1,3 @@
-const { bool, boolean } = require("joi");
 const mongoose = require("mongoose");
 const { v4: uuidv4 } = require('uuid');
 
@@ -16,7 +15,12 @@ const passSchema = new mongoose.Schema({
 	passStatus: {	
 		type: String,
 		enum: ["active", "inactive", "expired", "revoked"],
-		default: "active",
+		default: "inactive",
+	},
+	status: {
+		type: String,
+		enum: ["pending", "active", "payment_failed", "expired", "revoked"],
+		default: "pending",
 	},
 	paymentStatus: {
 		type: String,
@@ -39,6 +43,19 @@ const passSchema = new mongoose.Schema({
 		type: Number,
 		required: true,
 		min: 0,
+	},
+	ticketCount: {
+		type: Number,
+		required: true,
+		default: 1,
+		min: 1,
+	},
+	seatsReserved: {
+		type: Boolean,
+		default: false,
+	},
+	expiresAt: {
+		type: Date,
 	},
 	paymentDetails: {
 		orderId: String,
@@ -73,6 +90,9 @@ const passSchema = new mongoose.Schema({
 			type: String,
 			enum: ["user", "friend"],
 			
+		},
+		personIndex: {
+			type: Number,
 		},
 		personName: {
 			type: String,
@@ -124,16 +144,19 @@ const passSchema = new mongoose.Schema({
 });
 
 passSchema.pre('save', function(next) {
-	if (!this.passUUID && this.passStatus === 'active') {
+	const isConfirmed = this.paymentStatus === 'completed' || this.status === 'active' || this.passStatus === 'active';
+
+	if (!this.passUUID && isConfirmed) {
 		this.passUUID = uuidv4();
 	}
-	if (this.passStatus === 'active' && (!this.qrStrings || this.qrStrings.length === 0)) {
+	if (isConfirmed && (!this.qrStrings || this.qrStrings.length === 0)) {
 		this.qrStrings = [];
 		this.qrStrings.push({
 			id: uuidv4(),
 			personType: "user",
 			personIndex: 0,
-			isScanned: false,
+			personName: "Main User",
+			qrScanned: false,
 			scannedAt: null
 		});
 		
@@ -142,7 +165,9 @@ passSchema.pre('save', function(next) {
 			this.qrStrings.push({
 				id: uuidv4(),
 				personType: "friend",
-				isScanned: false,
+				personIndex: i + 1,
+				personName: this.friends[i]?.name || `Friend ${i + 1}`,
+				qrScanned: false,
 				scannedAt: null
 			});
 		}
@@ -155,30 +180,25 @@ passSchema.methods.getQRData = function() {
 	return this.qrStrings.map(qr => ({
 		id: qr.id,
 		personType: qr.personType,
-		personName: qr.personName,
 		personName: qr.personType === "user" ? "Main User" : 
 					this.friends[qr.personIndex - 1]?.name || `Friend ${qr.personIndex}`,
-		isScanned: qr.isScanned,
+		qrScanned: qr.qrScanned,
 		scannedAt: qr.scannedAt,
 		qrContent: `${this.eventId}_${this.passUUID}_${qr.id}_${qr.personName}`
 	}));
 };
 
 passSchema.methods.markQRScanned = function(qrId) {
-	let flag= true;
-	const qrString = this.qrStrings.find(qr => qr.id === qrId);
-	if (qrString && !qrString.isScanned) {
-		qrString.isScanned = true;
+	const qrString = this.qrStrings.find(qr => qr.id === qrId || qr._id?.toString() === qrId);
+	if (qrString && !qrString.qrScanned) {
+		qrString.qrScanned = true;
 		qrString.scannedAt = new Date();
-		for (let i = 0; i < this.qrStrings.length; i++) {
-			if (this.qrStrings[qrScanned]==false) {
-				flag = false;
-				break;}
 
-		if (!this.isScanned && flag) {
+		const allScanned = this.qrStrings.every(qr => qr.qrScanned);
+		if (!this.isScanned && allScanned) {
 			this.isScanned = true;
 			this.timeScanned = new Date();
-		}}
+		}
 		
 		return this.save();
 	}
@@ -186,15 +206,18 @@ passSchema.methods.markQRScanned = function(qrId) {
 };
 
 passSchema.statics.validateQRString = async function(qrId) {
-	const pass = await this.findOne({ "qrStrings.id": qrId });
+	const query = mongoose.Types.ObjectId.isValid(qrId)
+		? { $or: [{ "qrStrings._id": qrId }, { "qrStrings.id": qrId }] }
+		: { "qrStrings.id": qrId };
+	const pass = await this.findOne(query);
 	if (!pass) {
 		return { valid: false, message: "Invalid QR code" };
 	}
-	const qrString = pass.qrStrings.find(qr => qr.id === qrId);
-	if (qrString.isScanned) {
+	const qrString = pass.qrStrings.find(qr => qr.id === qrId || qr._id?.toString() === qrId);
+	if (qrString.qrScanned) {
 		return { valid: false, message: "QR code already scanned" };
 	}
-	if (pass.passStatus !== 'active') {
+	if (pass.paymentStatus !== 'completed' || (pass.status && pass.status !== 'active')) {
 		return { valid: false, message: "Pass is not active" };
 	}
 	return { valid: true, pass, qrString };

--- a/Server/src/models/teams.model.js
+++ b/Server/src/models/teams.model.js
@@ -1,0 +1,75 @@
+const mongoose = require("mongoose");
+
+const teamMemberSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    email: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    phoneNumber: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    joinedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { _id: false },
+);
+
+const teamSchema = new mongoose.Schema(
+  {
+    eventId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Event",
+      required: true,
+      index: true,
+    },
+    teamName: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 2,
+      maxlength: 80,
+    },
+    teamCode: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    teamLeader: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    teamMembers: {
+      type: [teamMemberSchema],
+      default: [],
+    },
+    maxMembers: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+  },
+  { timestamps: true },
+);
+
+teamSchema.index({ eventId: 1, teamName: 1 }, { unique: true });
+
+module.exports = mongoose.model("Team", teamSchema);

--- a/Server/src/routes/router.js
+++ b/Server/src/routes/router.js
@@ -4,6 +4,7 @@ const auth = require("../middleware/oauth.js");
 const authentication = require("./../controllers/authentication.js");
 const Events = require("./../controllers/event.controller.js");
 const Passes = require("./../controllers/passes.controller.js");
+const Teams = require("./../controllers/team.controller.js");
 const { checkRole } = require("../middleware/role.middleware.js");
 const { influencerValidation } = require("../helpers/validatorHelper.js");
 router.get(
@@ -54,6 +55,8 @@ router.get("/logout", authentication.logout);
 router.use(auth.verifyToken);
 router.post("/register", influencerValidation, Events.registerForInfluencer);
 
+router.post("/createTeam", Teams.createTeam);
+router.post("/joinTeam", Teams.joinTeam);
 router.post("/api/book-ticket", Passes.bookTicket);
 router.get("/api/passbyuuid/:passUUID", Passes.getPassByUUID);
 router.post("/api/getTix", Passes.getPassByQrStringsAndPassUUID);

--- a/Server/src/routes/router.js
+++ b/Server/src/routes/router.js
@@ -10,6 +10,16 @@ router.get(
   "/api/payment/callback/:merchantOrderId",
   Passes.handlePaymentCallback,
 );
+router.post(
+  "/api/payment/webhook",
+  express.raw({ type: "application/json" }),
+  Passes.handlePaymentWebhook,
+);
+router.post(
+  "/payment/webhook",
+  express.raw({ type: "application/json" }),
+  Passes.handlePaymentWebhook,
+);
 router.use((req, res, next) => {
   const csp = [
     "default-src 'self'",
@@ -45,11 +55,6 @@ router.use(auth.verifyToken);
 router.post("/register", influencerValidation, Events.registerForInfluencer);
 
 router.post("/api/book-ticket", Passes.bookTicket);
-router.post(
-  "/payment/webhook",
-  express.raw({ type: "application/json" }), // For webhook raw body handling
-  Passes.handlePaymentWebhook,
-);
 router.get("/api/passbyuuid/:passUUID", Passes.getPassByUUID);
 router.post("/api/getTix", Passes.getPassByQrStringsAndPassUUID);
 // Event Interaction Routes

--- a/Server/test/payment-logic.test.js
+++ b/Server/test/payment-logic.test.js
@@ -46,6 +46,16 @@ test("friend list is capped and normalized", () => {
   assert.equal(sanitized[8].email, "friend8@example.com");
 });
 
+test("basic-pass gated events come from env configuration", () => {
+  const previousEventIds = process.env.BASIC_PASS_REQUIRED_EVENT_IDS;
+
+  process.env.BASIC_PASS_REQUIRED_EVENT_IDS = " event-a, event-b ,, ";
+
+  assert.deepEqual(_test.basicPassRequiredEventIds(), ["event-a", "event-b"]);
+
+  process.env.BASIC_PASS_REQUIRED_EVENT_IDS = previousEventIds;
+});
+
 test("QR strings are generated for buyer and friends as unscanned entries", () => {
   const qrStrings = _test.buildQRStrings(
     { name: "Buyer" },

--- a/Server/test/payment-logic.test.js
+++ b/Server/test/payment-logic.test.js
@@ -1,0 +1,96 @@
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const test = require("node:test");
+
+const { _test } = require("../src/controllers/passes.controller");
+
+test("PhonePe test credentials default to sandbox endpoints", () => {
+  const previousEnv = process.env.PHONEPE_ENV;
+  const previousClientId = process.env.PHONEPE_CLIENT_ID;
+
+  delete process.env.PHONEPE_ENV;
+  process.env.PHONEPE_CLIENT_ID = "TEST-client-id";
+
+  assert.equal(
+    _test.getPhonePeConfig().BASE_URL,
+    "https://api-preprod.phonepe.com/apis/pg-sandbox",
+  );
+
+  process.env.PHONEPE_ENV = previousEnv;
+  process.env.PHONEPE_CLIENT_ID = previousClientId;
+});
+
+test("explicit production PhonePe env uses production endpoints without whitespace", () => {
+  const previousEnv = process.env.PHONEPE_ENV;
+
+  process.env.PHONEPE_ENV = "production";
+
+  assert.equal(
+    _test.getPhonePeConfig().BASE_URL,
+    "https://api.phonepe.com/apis/pg",
+  );
+
+  process.env.PHONEPE_ENV = previousEnv;
+});
+
+test("friend list is capped and normalized", () => {
+  const friends = Array.from({ length: 12 }, (_, index) => ({
+    name: index === 0 ? "" : `Friend ${index}`,
+    email: `friend${index}@example.com`,
+  }));
+
+  const sanitized = _test.sanitizeFriends(friends);
+
+  assert.equal(sanitized.length, 9);
+  assert.equal(sanitized[0].name, "Friend");
+  assert.equal(sanitized[8].email, "friend8@example.com");
+});
+
+test("QR strings are generated for buyer and friends as unscanned entries", () => {
+  const qrStrings = _test.buildQRStrings(
+    { name: "Buyer" },
+    [{ name: "A" }, { name: "B" }],
+  );
+
+  assert.equal(qrStrings.length, 3);
+  assert.equal(qrStrings[0].personName, "Buyer");
+  assert.equal(qrStrings[1].personType, "friend");
+  assert.equal(qrStrings[2].qrScanned, false);
+  assert.match(qrStrings[0].id, /^[0-9a-f-]{36}$/);
+});
+
+test("PhonePe status normalizer supports wrapped and top-level responses", () => {
+  assert.deepEqual(
+    _test.normalizePhonePeStatus({
+      data: { state: "COMPLETED", orderId: "order-1", amount: 1000 },
+    }),
+    {
+      state: "COMPLETED",
+      orderId: "order-1",
+      amount: 1000,
+      paymentDetails: [],
+      reason: undefined,
+    },
+  );
+
+  assert.equal(
+    _test.normalizePhonePeStatus({ state: "FAILED", reason: "DECLINED" }).reason,
+    "DECLINED",
+  );
+});
+
+test("webhook signature uses SHA256 username:password", () => {
+  const signature = crypto
+    .createHash("sha256")
+    .update("ritesh:ritesh123")
+    .digest("hex");
+
+  assert.equal(
+    _test.validateWebhookSignature("ritesh", "ritesh123", signature),
+    true,
+  );
+  assert.equal(
+    _test.validateWebhookSignature("ritesh", "ritesh123", "bad-signature"),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- Fixes paid and free pass booking behavior, including seat reservation/release and QR generation after successful payment.
- Adds missing team registration backend routes and models, and wires team bookings into the event payment/pass flow.
- Removes hardcoded event/payment/frontend values in favor of environment configuration.
- Fixes the event registration path so free event registration creates a pass directly instead of routing users to the old /register form.
- Adds safer PhonePe sandbox/production endpoint selection and webhook/callback handling.
- Applies safe npm audit fixes without forcing major upgrades.

## Testing
- Server: npm test
- Client: npm run lint
- Client: npm run build
- Local smoke checks for frontend pages, backend /getEvents, team routes without auth, and payment webhook auth behavior.

## Notes
- Real PhonePe sandbox credentials were rejected with 401. Production PhonePe credentials authenticated and created a test order, but those credentials are not included in this PR and should stay in env only.
- The newest local commit Improve PhonePe credential diagnostics is not on this PR yet because GitHub rejected direct updates to this branch.